### PR TITLE
Restrict RPC Idents

### DIFF
--- a/src/procedures/iotscape/iotscape.js
+++ b/src/procedures/iotscape/iotscape.js
@@ -25,10 +25,9 @@ const RESERVED_SERVICE_NAMES = fs.readdirSync(path.join(__dirname, '..'))
     .map(normalizeServiceName);
 const MONGODB_DOC_TOO_LARGE = 'Attempt to write outside buffer bounds';
 
-const isValidServiceName = name => !RESERVED_SERVICE_NAMES.includes(normalizeServiceName(name));
-
+const isValidServiceName = name => isValidIdent(name) && !RESERVED_SERVICE_NAMES.includes(normalizeServiceName(name));
 const isValidRPCName = name => isValidIdent(name) && !RESERVED_RPC_NAMES.includes(name);
-const isValidRPCArgName = name => isValidIdent(name);
+const isValidArgName = name => isValidIdent(name);
 
 const IoTScape = {};
 IoTScape.serviceName = 'IoTScape';
@@ -236,7 +235,7 @@ async function _mergeWithExistingService(name, service) {
     if (existing !== null) {
         const methodNames = _.uniq(
             [...service.methods, ...existing.methods]
-            .filter(method => isValidRPCName(method.name) && method.arguments.every(arg => isValidRPCArgName(arg.name))) // validate methods
+            .filter(method => isValidRPCName(method.name) && method.arguments.every(arg => isValidArgName(arg.name))) // validate methods
             .map(method => method.name)
         );
 

--- a/src/procedures/iotscape/iotscape.js
+++ b/src/procedures/iotscape/iotscape.js
@@ -127,12 +127,18 @@ IoTScape._createService = async function(definition, remote) {
 
     // Validate service name
     if(!isValidServiceName(name) || name.replace(/[^a-zA-Z0-9]/g, '') !== name){
-        logger.log(`Service name ${name} rejected`);
+        logger.log(`Service ${name} rejected due to invalid name`);
         return;
     }
 
     const serviceInfo = parsed.service;
     const methodsInfo = parsed.methods;
+
+    // Validate method names
+    if(!Object.keys(methodsInfo).every(method => isValidRPCName(method) && methodsInfo[method].params.every(param => isValidArgName(param.name)))){
+        logger.log(`Service ${name} rejected due to invalid method`);
+        return;
+    }
 
     const version = serviceInfo.version;
     const id = parsed.id;

--- a/src/procedures/service-creation/service-creation.js
+++ b/src/procedures/service-creation/service-creation.js
@@ -11,6 +11,8 @@ const _ = require('lodash');
 const Blocks = require('./blocks');
 const Storage = require('../../storage');
 const ServiceEvents = require('../utils/service-events');
+const { assertValidIdent } = require('../../utils');
+
 let mongoCollection = null;
 const getDatabase = function() {
     if (!mongoCollection) {
@@ -294,6 +296,8 @@ ServiceCreation.createServiceFromTable = async function(name, data, options) {
                 method.initialValue = initialValue;
             }
         }
+
+        method.arguments.forEach(x => assertValidIdent(x));
 
         return method;
     });

--- a/src/procedures/service-creation/service-creation.js
+++ b/src/procedures/service-creation/service-creation.js
@@ -267,6 +267,8 @@ ServiceCreation.createServiceFromTable = async function(name, data, options) {
     const defaultOptions = this.getCreateFromTableOptions(data);
     options = resolveOptions(options, defaultOptions);
 
+    assertValidIdent(name);
+
     const methods = options.RPCs.map(rpc => {
         const {name, help='', code, query, transform, combine, initialValue} = rpc;
         const method = {name, help};
@@ -297,6 +299,7 @@ ServiceCreation.createServiceFromTable = async function(name, data, options) {
             }
         }
 
+        assertValidIdent(method.name);
         method.arguments.forEach(x => assertValidIdent(x));
 
         return method;

--- a/src/services-worker.js
+++ b/src/services-worker.js
@@ -136,10 +136,10 @@ class ServicesWorker {
                     process.exit(1);
                 }
                 for (const rpc of service._docs.rpcs) {
-                    if (rpc.name.startsWith('_')) continue; // private/deprecated rpcs can be ignored
+                    if (rpc.name.startsWith('_')) continue; // private rpcs can be ignored
 
                     try {
-                        utils.assertValidIdent(rpc.name.replace(/[*]*/g, '')); // allow an extra set of legal trailing characters
+                        utils.assertValidIdent(rpc.name.replace(/[*]*$/, '')); // allow an extra set of legal trailing characters
                     } catch (ex) {
                         this._logger.error(`\nInvalid RPC name for '${service.serviceName}.${rpc.name}': ${ex}`);
                         process.exit(1);

--- a/src/utils.js
+++ b/src/utils.js
@@ -246,6 +246,14 @@ function assertValidIdent(ident) {
         throw Error(`'${ident}' is not a valid identifier: ${cause}`);
     }
 }
+function isValidIdent(ident) {
+    try {
+        assertValidIdent(ident);
+        return true;
+    } catch {
+        return false;
+    }
+}
 
 module.exports = {
     serialize,
@@ -270,4 +278,5 @@ module.exports = {
     sleep,
     defer,
     assertValidIdent,
+    isValidIdent,
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -235,6 +235,18 @@ function ninvoke(obj, method, ...args) {
     return deferred.promise;
 }
 
+function assertValidIdent(ident) {
+    if (!ident.match(/^[a-zA-Z](?:[a-zA-Z0-9\-_ ]*[a-zA-Z0-9])?$/)) {
+        let cause;
+        if (!ident.length) cause = 'Must not be empty string';
+        else if (!ident[0].match(/[a-zA-Z]/)) cause = 'Must start with a letter';
+        else if (!ident[ident.length - 1].match(/[a-zA-Z0-9]/)) cause = 'Must end with a letter or number';
+        else cause = 'Contained an invalid character';
+
+        throw Error(`'${ident}' is not a valid identifier: ${cause}`);
+    }
+}
+
 module.exports = {
     serialize,
     serializeArray,
@@ -257,4 +269,5 @@ module.exports = {
     getNewClientId,
     sleep,
     defer,
+    assertValidIdent,
 };

--- a/test/procedures/wildcam.spec.js
+++ b/test/procedures/wildcam.spec.js
@@ -1,4 +1,4 @@
-const utils = require('../../../../assets/utils');
+const utils = require('../assets/utils');
 
 describe(utils.suiteName(__filename), function() {
     utils.verifyRPCInterfaces('Wildcam', [

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -1,0 +1,64 @@
+const utils = require('./assets/utils.js');
+
+describe(utils.suiteName(__filename), function() {
+    const assert = require('assert');
+    const lib = utils.reqSrc('utils');
+
+    describe('ident checker', () => {
+        it('should accept C identifiers', () => {
+            assert(lib.isValidIdent('foo'));
+            assert(lib.isValidIdent('fooBar'));
+            assert(lib.isValidIdent('foo4Bar'));
+            assert(lib.isValidIdent('foo4Bar'));
+            assert(lib.isValidIdent('foo4Bar5'));
+            assert(lib.isValidIdent('foo4Bar5'));
+        });
+
+        it('should accept several word separators', () => {
+            assert(lib.isValidIdent('foo'));
+            assert(lib.isValidIdent('foo Bar'));
+            assert(lib.isValidIdent('foo4-Bar'));
+            assert(lib.isValidIdent('foo4_Bar'));
+            assert(lib.isValidIdent('foo 4 Bar5'));
+            assert(lib.isValidIdent('f-o-- o4Ba__r5'));
+        });
+
+        it('should forbid illegal characters', () => {
+            assert(!lib.isValidIdent('fo$o'));
+            assert(!lib.isValidIdent('fo+o'));
+            assert(!lib.isValidIdent('f(oo)'));
+            assert(!lib.isValidIdent('fo*o'));
+            assert(!lib.isValidIdent('f%oo'));
+            assert(!lib.isValidIdent('f#oo'));
+            assert(!lib.isValidIdent('f\'oo'));
+            assert(!lib.isValidIdent('f\"oo'));
+            assert(!lib.isValidIdent('f`oo'));
+            assert(!lib.isValidIdent('f:oo'));
+            assert(!lib.isValidIdent('f;oo'));
+            assert(!lib.isValidIdent('f?oo'));
+            assert(!lib.isValidIdent('f,oo'));
+        });
+
+        it('should not allow leading or trailing separators', () => {
+            assert(!lib.isValidIdent(' foo'));
+            assert(!lib.isValidIdent('-foo'));
+            assert(!lib.isValidIdent('_foo'));
+
+            assert(!lib.isValidIdent('foo '));
+            assert(!lib.isValidIdent('foo-'));
+            assert(!lib.isValidIdent('foo_'));
+        });
+
+        it('should not allow digits at the beginning', () => {
+            assert(!lib.isValidIdent('0foo'));
+            assert(!lib.isValidIdent('1foo'));
+            assert(!lib.isValidIdent('2foo'));
+        });
+
+        it('should allow digits at the end', () => {
+            assert(lib.isValidIdent('foo0'));
+            assert(lib.isValidIdent('foo1'));
+            assert(lib.isValidIdent('foo2'));
+        });
+    });
+});


### PR DESCRIPTION
[Problem Origin](https://github.com/NetsBlox/Snap--Build-Your-Own-Blocks/pull/1347). Adds a utility called `assertValidIdent` that can be used to check identifiers for all service-creation features. Currently, this is only enforced in `ServiceCreation.createServiceFromTable`.

The current checker is very restrictive (mostly C ident plus common separators like `-_ `), but should allow 99% of all reasonable symbol names. All existing RPCs would pass this check except for some of the `Geolocation` services that have an asterisk in their name. But that's fine since this is technically only used for user-created services (and specifically only new services).

_Note: the change to `ServiceCreation` is currently untested because logging in doesn't seem to be working (created a test user, but logging in gives a "must be logged in" error since the `netsblox` cookie gets rejected due to invalid domain)_