### PR TITLE
Allow requests from clients w/o known state

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -169,8 +169,8 @@ class ServicesAPI {
         ctx.request = req;
         const {username, state} = await NetsBloxCloud.getClientInfo(clientId)
         // TODO: add support for external states, too?
-        const projectId = state.browser?.projectId;
-        const roleId = state.browser?.roleId;
+        const projectId = state?.browser?.projectId;
+        const roleId = state?.browser?.roleId;
 
         ctx.caller = {
             username,


### PR DESCRIPTION
Previously, this could cause an error which results in a server crash. This blocks the release of this version of the services server as it makes a DoS attack trivial.