### PR TITLE
Fixed issue with checking api key without username

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -179,8 +179,8 @@ class ServicesAPI {
             clientId,
         };
         const apiKey = this.services.getApiKey(serviceName);
-        console.log({apiKey});
-        if (apiKey) {
+        const isLoggedIn = !!username;
+        if (apiKey && isLoggedIn){
             // TODO: handle invalid settings (parse error)
             const settings = await NetsBloxCloud.getServiceSettings(username);
             const apiKeyValue = await ApiKeys.get(apiKey, settings);


### PR DESCRIPTION
Fixed username check with api key. While using Api Consumer