### PR TITLE
Set docker build action to use v4

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -32,7 +32,7 @@ jobs:
         if: github.event_name == 'push'
         
       - name: Publish to Docker Hub
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v4
         with:
           name: netsblox/services
           username: ${{ secrets.DOCKER_HUB_USERNAME }}


### PR DESCRIPTION
This change was made to resolve a deprecation warning in the github actions. 
```
>> elgohr/Publish-Docker-Github-Action@master has been deprecated.
>> Please use elgohr/Publish-Docker-Github-Action@v4 for a blast in speed and security.
```