### PR TITLE
Parse user/member/groups service settings. Fix #104

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -193,7 +193,6 @@ class ServicesAPI {
     const isLoggedIn = !!username;
     if (apiKey && isLoggedIn) {
       // TODO: handle invalid settings (parse error)
-      const settings = await NetsBloxCloud.getServiceSettings(username);
       const apiKeyValue = await this.keys.get(username, apiKey); // TODO: double check this
       if (apiKeyValue) {
         ctx.apiKey = apiKeyValue;

--- a/src/cloud-client.js
+++ b/src/cloud-client.js
@@ -70,13 +70,12 @@ class NetsBloxCloud {
   async getServiceSettings(username) {
     const url = `/services/settings/user/${username}/${this.id}/all`;
     const settings = await this.get(url);
-    return _.mapValues(settings, (value) => {
-      if (value) {
-        if (value.map) return value.map(JSON.parse);
-        return JSON.parse(value);
-      }
-      return value;
-    });
+    // settings fields are strings which we happen to use to store JSON
+    // so we need to JSON.parse them, too
+    settings.user = JSON.parse(settings.user);
+    settings.member = JSON.parse(settings.member);
+    settings.groups = _.mapValues(settings.groups, JSON.parse);
+    return settings;
   }
 
   async getUserServiceSettings(username) {


### PR DESCRIPTION
Parsing logic was incorrect for service settings. The response from the server is:
```
{
  user: <settingsString>,
  member: <settingsString>,
  group: {
    groupId: <settingsString>,
  }
}
```
and the response needs to be parsed appropriately. It had been assuming a uniform 1-level deep mapping of keys to strings which isn't the case for the `group` key.