### PR TITLE
deprecate broken this-x-dne rpcs

### DIFF
--- a/src/procedures/this-x-does-not-exist/this-x-does-not-exist.js
+++ b/src/procedures/this-x-does-not-exist/this-x-does-not-exist.js
@@ -34,6 +34,7 @@ TXDNE._getX = async function (rsp, url) {
 /**
  * Gets an image of a person that does not exist
  *
+ * @deprecated
  * @returns {Image} a random image of the given type
  */
 TXDNE.getPerson = function () {
@@ -46,6 +47,7 @@ TXDNE.getPerson = function () {
 /**
  * Gets an image of a cat that does not exist
  *
+ * @deprecated
  * @returns {Image} a random image of the given type
  */
 TXDNE.getCat = function () {
@@ -55,6 +57,7 @@ TXDNE.getCat = function () {
 /**
  * Gets an image of a horse that does not exist
  *
+ * @deprecated
  * @returns {Image} a random image of the given type
  */
 TXDNE.getHorse = function () {
@@ -64,6 +67,7 @@ TXDNE.getHorse = function () {
 /**
  * Gets an image of an artwork that does not exist
  *
+ * @deprecated
  * @returns {Image} a random image of the given type
  */
 TXDNE.getArtwork = function () {

--- a/test/procedures/this-x-does-not-exist.spec.js
+++ b/test/procedures/this-x-does-not-exist.spec.js
@@ -1,7 +1,9 @@
+'use strict';
+
 const utils = require("../assets/utils");
 
 describe(utils.suiteName(__filename), function () {
-  utils.verifyRPCInterfaces("ThisXDoesNotExist", [
+  const rpcs = [
     ["getPerson", []],
     ["getCat", []],
     ["getHorse", []],
@@ -11,5 +13,32 @@ describe(utils.suiteName(__filename), function () {
     ["getPony", []],
     ["getHomeInterior", []],
     ["getCongressPerson", []],
-  ]);
+  ];
+  const deprecated = [
+    'getArtwork',
+    'getPerson',
+    'getCat',
+    'getHorse',
+  ];
+  utils.verifyRPCInterfaces("ThisXDoesNotExist", rpcs);
+
+  const xdneSrc = utils.reqSrc("procedures/this-x-does-not-exist/this-x-does-not-exist");
+  const RPCMock = require("../assets/mock-service");
+  let xdne;
+
+  before(async () => {
+    xdne = new RPCMock(xdneSrc);
+  });
+  after(() => {
+    xdne.destroy();
+  });
+
+  describe("rpcs", function () {
+    for (const [rpc, params] of rpcs) {
+      if (params.length !== 0 || deprecated.some(x => x === rpc)) continue;
+      it(`should successfully invoke '${rpc}'`, async function () {
+        await xdne[rpc]();
+      });
+    }
+  });
 });

--- a/test/procedures/this-x-does-not-exist.spec.js
+++ b/test/procedures/this-x-does-not-exist.spec.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 
 const utils = require("../assets/utils");
 
@@ -15,14 +15,16 @@ describe(utils.suiteName(__filename), function () {
     ["getCongressPerson", []],
   ];
   const deprecated = [
-    'getArtwork',
-    'getPerson',
-    'getCat',
-    'getHorse',
+    "getArtwork",
+    "getPerson",
+    "getCat",
+    "getHorse",
   ];
   utils.verifyRPCInterfaces("ThisXDoesNotExist", rpcs);
 
-  const xdneSrc = utils.reqSrc("procedures/this-x-does-not-exist/this-x-does-not-exist");
+  const xdneSrc = utils.reqSrc(
+    "procedures/this-x-does-not-exist/this-x-does-not-exist",
+  );
   const RPCMock = require("../assets/mock-service");
   let xdne;
 
@@ -35,7 +37,7 @@ describe(utils.suiteName(__filename), function () {
 
   describe("rpcs", function () {
     for (const [rpc, params] of rpcs) {
-      if (params.length !== 0 || deprecated.some(x => x === rpc)) continue;
+      if (params.length !== 0 || deprecated.some((x) => x === rpc)) continue;
       it(`should successfully invoke '${rpc}'`, async function () {
         await xdne[rpc]();
       });


### PR DESCRIPTION
Ironically, some this-x-does-not-exist providers no longer exist. Since we're in the process of setting up a server to directly do prompt-based image generation, just deprecating these broken rpcs should be fine for now so they don't show in the rpc menu.