### PR TITLE
add YearSince type

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts
+FROM node:lts-bookworm
 MAINTAINER Brian Broll <brian.broll@vanderbilt.edu>
 
 ADD . /netsblox
@@ -14,7 +14,7 @@ RUN cd /tmp && \
 	cp -av lib/x86_64-linux-gnu/* /usr/lib/x86_64-linux-gnu/
 
 # Install updated C++ std lib (required for NodeHun)
-RUN apt-get install -y libstdc++-10-dev gnuplot \
+RUN apt-get install -y libstdc++-11-dev gnuplot \
   libsdl-pango-dev libgif-dev  # Required for canvas (chart service)
 
 # Clean up and install NetsBlox dependencies

--- a/src/input-types.js
+++ b/src/input-types.js
@@ -529,6 +529,13 @@ defineType({
 });
 
 defineType({
+  name: "YearSince",
+  description: "A year starting at some point and ranging up to the current year",
+  baseType: "BoundedInteger",
+  baseParams: (p) => [p[0], new Date().getFullYear()],
+});
+
+defineType({
   name: "BoundedString",
   description: "A string (text) with a minimum and/or maximum length.",
   baseType: "String",

--- a/src/procedures/hurricane-data/hurricane-data.js
+++ b/src/procedures/hurricane-data/hurricane-data.js
@@ -135,7 +135,7 @@ async function getData() {
  * Get hurricane data including location, maximum winds, and central pressure.
  *
  * @param {String} name - name of the hurricane
- * @param {BoundedNumber<1850,2020>} year - year that the hurricane occurred in
+ * @param {YearSince<1850>} year - year that the hurricane occurred in
  * @returns {Array<Object>} - All recorded data for the given hurricane
  */
 HurricaneData.getHurricaneData = async function (name, year) {
@@ -149,10 +149,9 @@ HurricaneData.getHurricaneData = async function (name, year) {
 /**
  * Get the names of all hurricanes occurring in the given year.
  *
- * @param {BoundedNumber<1850,2020>} year
+ * @param {YearSince<1850>} year
  * @returns {Array<String>} names
  */
-
 HurricaneData.getHurricanesInYear = async function (year) {
   const names = (await getData())
     .filter((data) => data.year == year)
@@ -165,7 +164,7 @@ HurricaneData.getHurricanesInYear = async function (year) {
  * Get the years in which a hurricane with the given name occurred.
  *
  * @param {String} name - name of the hurricane to find the year(s) of
- * @returns {Array<Number>} years - list with all of the years that a particular name has been used for a hurricane
+ * @returns {Array<Integer>} years - list with all of the years that a particular name has been used for a hurricane
  */
 HurricaneData.getYearsWithHurricaneNamed = async function (name) {
   name = name.toUpperCase();

--- a/test/input-types.spec.js
+++ b/test/input-types.spec.js
@@ -110,8 +110,12 @@ describe(utils.suiteName(__filename), function () {
     it("should forbid years outside the range", async () => {
       await utils.shouldThrow(() => typesParser.YearSince("1948", [1950]));
       await utils.shouldThrow(() => typesParser.YearSince("1949", [1950]));
-      await utils.shouldThrow(() => typesParser.YearSince(new Date().getFullYear() + 1, [1950]));
-      await utils.shouldThrow(() => typesParser.YearSince(new Date().getFullYear() + 2, [1950]));
+      await utils.shouldThrow(() =>
+        typesParser.YearSince(new Date().getFullYear() + 1, [1950])
+      );
+      await utils.shouldThrow(() =>
+        typesParser.YearSince(new Date().getFullYear() + 2, [1950])
+      );
     });
     it("should forbid non-integers", async () => {
       await utils.shouldThrow(() => typesParser.YearSince("1975.2", [1950]));
@@ -120,9 +124,24 @@ describe(utils.suiteName(__filename), function () {
       assert.deepStrictEqual(await typesParser.YearSince("1950", [1950]), 1950);
       assert.deepStrictEqual(await typesParser.YearSince("1951", [1950]), 1951);
       assert.deepStrictEqual(await typesParser.YearSince("1952", [1950]), 1952);
-      assert.deepStrictEqual(await typesParser.YearSince((new Date().getFullYear() - 2).toString(), [1950]), new Date().getFullYear() - 2);
-      assert.deepStrictEqual(await typesParser.YearSince((new Date().getFullYear() - 1).toString(), [1950]), new Date().getFullYear() - 1);
-      assert.deepStrictEqual(await typesParser.YearSince(new Date().getFullYear().toString(), [1950]), new Date().getFullYear());
+      assert.deepStrictEqual(
+        await typesParser.YearSince((new Date().getFullYear() - 2).toString(), [
+          1950,
+        ]),
+        new Date().getFullYear() - 2,
+      );
+      assert.deepStrictEqual(
+        await typesParser.YearSince((new Date().getFullYear() - 1).toString(), [
+          1950,
+        ]),
+        new Date().getFullYear() - 1,
+      );
+      assert.deepStrictEqual(
+        await typesParser.YearSince(new Date().getFullYear().toString(), [
+          1950,
+        ]),
+        new Date().getFullYear(),
+      );
     });
   });
 

--- a/test/input-types.spec.js
+++ b/test/input-types.spec.js
@@ -106,6 +106,26 @@ describe(utils.suiteName(__filename), function () {
     });
   });
 
+  describe("YearSince", function () {
+    it("should forbid years outside the range", async () => {
+      await utils.shouldThrow(() => typesParser.YearSince("1948", [1950]));
+      await utils.shouldThrow(() => typesParser.YearSince("1949", [1950]));
+      await utils.shouldThrow(() => typesParser.YearSince(new Date().getFullYear() + 1, [1950]));
+      await utils.shouldThrow(() => typesParser.YearSince(new Date().getFullYear() + 2, [1950]));
+    });
+    it("should forbid non-integers", async () => {
+      await utils.shouldThrow(() => typesParser.YearSince("1975.2", [1950]));
+    });
+    it("should parse valid years", async () => {
+      assert.deepStrictEqual(await typesParser.YearSince("1950", [1950]), 1950);
+      assert.deepStrictEqual(await typesParser.YearSince("1951", [1950]), 1951);
+      assert.deepStrictEqual(await typesParser.YearSince("1952", [1950]), 1952);
+      assert.deepStrictEqual(await typesParser.YearSince((new Date().getFullYear() - 2).toString(), [1950]), new Date().getFullYear() - 2);
+      assert.deepStrictEqual(await typesParser.YearSince((new Date().getFullYear() - 1).toString(), [1950]), new Date().getFullYear() - 1);
+      assert.deepStrictEqual(await typesParser.YearSince(new Date().getFullYear().toString(), [1950]), new Date().getFullYear());
+    });
+  });
+
   describe("Array", function () {
     it("should throw error w/ numeric input", async () => {
       let rawInput = "181",


### PR DESCRIPTION
Closes #142. Adds a new input type `YearSince<start>` which is semantically an alias for `BoundedInteger<start, current year>`.

I'm still having issues with my local deployment, so this is currently untested, but should work.