### PR TITLE
Set the node image to node v18 instead of LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-bookworm
+FROM node:18-bookworm
 MAINTAINER Brian Broll <brian.broll@vanderbilt.edu>
 
 ADD . /netsblox


### PR DESCRIPTION
Although it is nice to use LTS, it is really annoying when the docker build
fails in CD due to an incompability introduced by lts targeting a different
node version.

Rather than having this fail in the commit, this requires us to manually
update the node version in the image. A little more tedium in exchange for
fewer surprises.
