### PR TITLE
Handle undefined service in getArgumentNames

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -150,7 +150,7 @@ class ServicesAPI {
 
   getArgumentNames(serviceName, rpcName) {
     const service = this.services.metadata[serviceName];
-    return service?.rpcs[rpcName].args.map((arg) => arg.name) ?? []; 
+    return service?.rpcs[rpcName].args.map((arg) => arg.name) ?? [];
   }
 
   validateRPCRequest(serviceName, req, res) {

--- a/src/api.js
+++ b/src/api.js
@@ -150,7 +150,7 @@ class ServicesAPI {
 
   getArgumentNames(serviceName, rpcName) {
     const service = this.services.metadata[serviceName];
-    return service.rpcs[rpcName].args.map((arg) => arg.name);
+    return service?.rpcs[rpcName].args.map((arg) => arg.name);
   }
 
   validateRPCRequest(serviceName, req, res) {

--- a/src/api.js
+++ b/src/api.js
@@ -150,7 +150,7 @@ class ServicesAPI {
 
   getArgumentNames(serviceName, rpcName) {
     const service = this.services.metadata[serviceName];
-    return service?.rpcs[rpcName].args.map((arg) => arg.name);
+    return service?.rpcs[rpcName].args.map((arg) => arg.name) ?? []; 
   }
 
   validateRPCRequest(serviceName, req, res) {

--- a/src/services-worker.js
+++ b/src/services-worker.js
@@ -286,9 +286,12 @@ class ServicesWorker {
 
   invoke(context, serviceName, rpcName, args) {
     const rpc = this.getServiceInstance(serviceName, context.caller.projectId);
-    const ctx = Object.create(rpc);
-    Object.assign(ctx, context);
-    return this.callRPC(rpcName, ctx, args);
+
+    if(rpc) {
+      const ctx = Object.create(rpc);
+      Object.assign(ctx, context);
+      return this.callRPC(rpcName, ctx, args);
+    }
   }
 
   getServiceInstance(name, projectId) {

--- a/src/services-worker.js
+++ b/src/services-worker.js
@@ -287,7 +287,7 @@ class ServicesWorker {
   invoke(context, serviceName, rpcName, args) {
     const rpc = this.getServiceInstance(serviceName, context.caller.projectId);
 
-    if(rpc) {
+    if (rpc) {
       const ctx = Object.create(rpc);
       Object.assign(ctx, context);
       return this.callRPC(rpcName, ctx, args);


### PR DESCRIPTION
Prevents another crash

@brollb Is it okay if this returns something like undefined now? I figure it's better than crashing.