### PR TITLE
Temporarily handle IoTScape request timeouts by returning string

### DIFF
--- a/src/procedures/iotscape/iotscape-services.js
+++ b/src/procedures/iotscape/iotscape-services.js
@@ -257,7 +257,7 @@ IoTScapeServices.call = async function (service, func, id, ...args) {
       result,
     ) => result).catch(() => {
       logger.log("IoTScape request timed out again, giving up");
-      throw new Error("Response timed out.");
+      return "Response timed out.";
     });
   });
 


### PR DESCRIPTION
Prevents a rare timing issue we will need to look into later.