### PR TITLE
IoTScape Improvements

### DIFF
--- a/src/community/device-service.js
+++ b/src/community/device-service.js
@@ -26,7 +26,7 @@ class DeviceService {
 
     this._docs = {
       description: record.description,
-      categories: [["Community", "Device"], ["Devices", "Community"]],
+      categories: [["Community", "Devices"], ["Devices", "Community"]],
       getDocFor: (method) => {
         let m = record.methods.find((val) => val.name == method);
         return {

--- a/src/community/device-service.js
+++ b/src/community/device-service.js
@@ -59,7 +59,7 @@ class DeviceService {
       };
     } else if (methodSpec.name === "send") {
       this[methodSpec.name] = async function () {
-        return IoTScape.send(this.serviceName, arguments[0], arguments[1]);
+        return IoTScape._send(this.serviceName, arguments[0], arguments[1], this.caller);
       };
     } else if (methodSpec.name === "getMessageTypes") {
       this[methodSpec.name] = async function () {
@@ -71,11 +71,11 @@ class DeviceService {
       };
     } else {
       this[methodSpec.name] = async function () {
-        console.dir(arguments);
-        return await IoTScape.send(
+        return await IoTScape._send(
           this.serviceName,
           arguments[0],
-          [methodSpec.name, ...Object.values(arguments).splice(1)].join(" "),
+          [methodSpec.name, ...Object.values(arguments).splice(1)].join(" "), 
+          this.caller
         );
       };
     }

--- a/src/community/device-service.js
+++ b/src/community/device-service.js
@@ -1,7 +1,7 @@
 const createLogger = require("../procedures/utils/logger");
 const IoTScapeServices = require("../procedures/iotscape/iotscape-services");
-const IoTScapeDevices = require('../procedures/iotscape/iotscape-devices');
-const IoTScape = require('../procedures/iotscape/iotscape');
+const IoTScapeDevices = require("../procedures/iotscape/iotscape-devices");
+const IoTScape = require("../procedures/iotscape/iotscape");
 
 /**
  * Represents a service created for a IoTScape device
@@ -26,7 +26,7 @@ class DeviceService {
 
     this._docs = {
       description: record.description,
-      categories: [['Community', 'Device'],['Devices', 'Community']],
+      categories: [["Community", "Device"], ["Devices", "Community"]],
       getDocFor: (method) => {
         let m = record.methods.find((val) => val.name == method);
         return {
@@ -57,23 +57,27 @@ class DeviceService {
           ...arguments,
         );
       };
-    } else if(methodSpec.name === 'send'){
-      this[methodSpec.name] = async function() {
-          return IoTScape.send(this.serviceName, arguments[0], arguments[1]);
+    } else if (methodSpec.name === "send") {
+      this[methodSpec.name] = async function () {
+        return IoTScape.send(this.serviceName, arguments[0], arguments[1]);
       };
-    } else if(methodSpec.name === 'getMessageTypes'){
-        this[methodSpec.name] = async function() {
-            return IoTScapeServices.getMessageTypes(this.serviceName);
-        };
-    } else if(methodSpec.name === 'getMethods'){
-        this[methodSpec.name] = async function() {
-            return IoTScapeServices.getMethods(this.serviceName);
-        };
+    } else if (methodSpec.name === "getMessageTypes") {
+      this[methodSpec.name] = async function () {
+        return IoTScapeServices.getMessageTypes(this.serviceName);
+      };
+    } else if (methodSpec.name === "getMethods") {
+      this[methodSpec.name] = async function () {
+        return IoTScapeServices.getMethods(this.serviceName);
+      };
     } else {
-        this[methodSpec.name] = async function () {
-            console.dir(arguments);
-            return await IoTScape.send(this.serviceName, arguments[0], [methodSpec.name, ...Object.values(arguments).splice(1)].join(' '));
-        };
+      this[methodSpec.name] = async function () {
+        console.dir(arguments);
+        return await IoTScape.send(
+          this.serviceName,
+          arguments[0],
+          [methodSpec.name, ...Object.values(arguments).splice(1)].join(" "),
+        );
+      };
     }
   }
 

--- a/src/community/device-service.js
+++ b/src/community/device-service.js
@@ -1,5 +1,7 @@
 const createLogger = require("../procedures/utils/logger");
 const IoTScapeServices = require("../procedures/iotscape/iotscape-services");
+const IoTScapeDevices = require('../procedures/iotscape/iotscape-devices');
+const IoTScape = require('../procedures/iotscape/iotscape');
 
 /**
  * Represents a service created for a IoTScape device
@@ -24,12 +26,13 @@ class DeviceService {
 
     this._docs = {
       description: record.description,
-      categories: [["Community", "Device"]],
+      categories: [['Community', 'Device'],['Devices', 'Community']],
       getDocFor: (method) => {
         let m = record.methods.find((val) => val.name == method);
         return {
           name: m.name,
           description: m.documentation,
+          categories: m.categories,
           args: m.arguments.map((argument) => ({
             name: argument.name,
             optional: argument.optional,
@@ -41,10 +44,10 @@ class DeviceService {
   }
 
   async _initializeRPC(methodSpec) {
-    // getDevices and listen have special implementations
+    // Default methods have special implementations
     if (methodSpec.name === "getDevices") {
       this[methodSpec.name] = async function () {
-        return IoTScapeServices.getDevices(this.serviceName);
+        return IoTScapeDevices.getDevices(this.serviceName);
       };
     } else if (methodSpec.name === "listen") {
       this[methodSpec.name] = async function () {
@@ -54,14 +57,23 @@ class DeviceService {
           ...arguments,
         );
       };
-    } else {
-      this[methodSpec.name] = async function () {
-        return await IoTScapeServices.call(
-          this.serviceName,
-          methodSpec.name,
-          ...arguments,
-        );
+    } else if(methodSpec.name === 'send'){
+      this[methodSpec.name] = async function() {
+          return IoTScape.send(this.serviceName, arguments[0], arguments[1]);
       };
+    } else if(methodSpec.name === 'getMessageTypes'){
+        this[methodSpec.name] = async function() {
+            return IoTScapeServices.getMessageTypes(this.serviceName);
+        };
+    } else if(methodSpec.name === 'getMethods'){
+        this[methodSpec.name] = async function() {
+            return IoTScapeServices.getMethods(this.serviceName);
+        };
+    } else {
+        this[methodSpec.name] = async function () {
+            console.dir(arguments);
+            return await IoTScape.send(this.serviceName, arguments[0], [methodSpec.name, ...Object.values(arguments).splice(1)].join(' '));
+        };
     }
   }
 

--- a/src/community/device-service.js
+++ b/src/community/device-service.js
@@ -59,7 +59,12 @@ class DeviceService {
       };
     } else if (methodSpec.name === "send") {
       this[methodSpec.name] = async function () {
-        return IoTScape._send(this.serviceName, arguments[0], arguments[1], this.caller);
+        return IoTScape._send(
+          this.serviceName,
+          arguments[0],
+          arguments[1],
+          this.caller,
+        );
       };
     } else if (methodSpec.name === "getMessageTypes") {
       this[methodSpec.name] = async function () {
@@ -74,8 +79,8 @@ class DeviceService {
         return await IoTScape._send(
           this.serviceName,
           arguments[0],
-          [methodSpec.name, ...Object.values(arguments).splice(1)].join(" "), 
-          this.caller
+          [methodSpec.name, ...Object.values(arguments).splice(1)].join(" "),
+          this.caller,
         );
       };
     }

--- a/src/procedures/iotscape/iotscape-devices.js
+++ b/src/procedures/iotscape/iotscape-devices.js
@@ -1,0 +1,207 @@
+const logger = require('../utils/logger')('iotscape-devices');
+const ciphers = require('../roboscape/ciphers');
+
+/**
+ * Stores information about registered devices, with a list of IDs and their respective hosts
+ */
+const IoTScapeDevices = {};
+IoTScapeDevices._services = {};
+IoTScapeDevices._encryptionStates = {};
+
+/**
+ * Encrypt a string with a device's encryption settings
+ * @param {String} service Service device is contained in
+ * @param {String} id ID of device to use encryption settings for
+ * @param {String} plaintext Plaintext to encrypt
+ * @returns Plaintext encrypted with device's encryption settings
+ */
+IoTScapeDevices.deviceEncrypt = function(service, id, plaintext){
+    let encryptionState = IoTScapeDevices.getEncryptionState(service, id);
+    return ciphers[encryptionState.cipher].encrypt(plaintext, encryptionState.key);
+};
+
+/**
+ * Encrypt a string with a device's encryption settings
+ * @param {String} service Service device is contained in
+ * @param {String} id ID of device to use encryption settings for
+ * @param {String} ciphertext Ciphertext to decrypt
+ * @returns Ciphertext decrypted with device's encryption settings
+ */
+IoTScapeDevices.deviceDecrypt = function(service, id, ciphertext){
+    let encryptionState = IoTScapeDevices.getEncryptionState(service, id);
+    return ciphers[encryptionState.cipher].decrypt(ciphertext, encryptionState.key);
+};
+
+/**
+ * Get the remote host of a IoTScape device
+ * @param {String} service Name of service
+ * @param {String} id ID of device
+ */
+IoTScapeDevices.getInfo = function(service, id){
+    return IoTScapeDevices._services[service][id];
+};
+
+/**
+ * Get a device's encryption settings (or defaults if not set)
+ * @param {String} service Service device is contained in
+ * @param {String} id ID of device to get encryption settings for
+ */
+IoTScapeDevices.getEncryptionState = function(service, id){
+    if(!IoTScapeDevices.deviceExists(service, id)){
+        throw new Error('Device not found');
+    }
+
+    if(!Object.keys(IoTScapeDevices._encryptionStates).includes(service)){
+        IoTScapeDevices._encryptionStates[service] = {};
+    }
+
+    if(!Object.keys(IoTScapeDevices._encryptionStates[service]).includes(id)){
+        // Create entry with default
+        IoTScapeDevices._encryptionStates[service][id] = {
+            key: [0],
+            cipher: 'plain'
+        };
+    }
+
+    const state = IoTScapeDevices._encryptionStates[service][id];
+
+    if(state.cipher == 'linked'){
+        return IoTScapeDevices.getEncryptionState(state.key.service, state.key.id);
+    }
+
+    return state;
+};
+
+
+/**
+ * Updates encryption settings for a device
+ * @param {String} service Service device is contained in
+ * @param {String} id ID of device to update encryption settings for
+ * @param {String=} key Key to set
+ * @param {String=} cipher Cipher to set
+ */
+IoTScapeDevices.updateEncryptionState = function(service, id, key = null, cipher = null) {
+    if(!IoTScapeDevices.deviceExists(service, id)){
+        throw new Error('Device not found');
+    }
+
+    if(!Object.keys(IoTScapeDevices._encryptionStates).includes(service)){
+        IoTScapeDevices._encryptionStates[service] = {};
+    }
+
+    if(!Object.keys(IoTScapeDevices._encryptionStates[service]).includes(id)){
+        // Create entry with default
+        IoTScapeDevices._encryptionStates[service][id] = {
+            key: [0],
+            cipher: 'plain'
+        };
+    }
+
+    // Update key if requested
+    if(key != null){
+        IoTScapeDevices._setKey(service, id, key, cipher);
+    }
+
+    // Update cipher if requested
+    cipher = (cipher || '').toLowerCase();
+    if(['linked', ...Object.keys(ciphers)].includes(cipher)){
+        IoTScapeDevices._encryptionStates[service][id].cipher = cipher;
+    } else if(cipher != ''){
+        // Prevent attempts to use ciphers with no implementation
+        throw new Error('Invalid cipher');
+    }
+};
+
+IoTScapeDevices._setKey = function(service, id, key, cipher){
+    // Set default cipher
+    if(IoTScapeDevices._encryptionStates[service][id].cipher === 'plain' && cipher == null){
+        cipher = 'caesar';
+    }
+
+    // Setting linked status does not require key to be parsed
+    if(cipher != 'linked'){
+        key = key.map(c => parseInt(c));        
+
+        if(key.includes(NaN)){
+            throw new Error('Invalid key');
+        }
+    }
+
+    IoTScapeDevices._encryptionStates[service][id].key = key;
+};
+
+/**
+ * Remove a device from a service
+ * @param {String} service Name of service
+ * @param {String} id ID of device to remove
+ */
+IoTScapeDevices.removeDevice = function(service, id) {
+    if(!IoTScapeDevices.deviceExists(service, id)){
+        return;
+    }
+
+    delete IoTScapeDevices._services[service][id];
+
+    if(Object.keys(IoTScapeDevices._encryptionStates).includes(service)){
+        delete IoTScapeDevices._encryptionStates[service][id];
+    }
+
+    if(IoTScapeDevices._listeningClients[service] !== undefined && IoTScapeDevices._listeningClients[service][id] !== undefined){
+        delete IoTScapeDevices._listeningClients[service][id];
+    }
+
+    logger.log(`Removed ${service}:${id}`);
+};
+
+/**
+ * List IDs of devices associated for a service
+ * @param {String} service Name of service to get device IDs for
+ */
+IoTScapeDevices.getDevices = function (service) {
+    const serviceDict = IoTScapeDevices._services[service];
+    return Object.keys(serviceDict || []);
+};
+
+/**
+ * Determine if a device with a given ID exists
+ * @param {String} service Name of service
+ * @param {String} id ID of device
+ * @returns {Boolean} If device exists
+ */
+IoTScapeDevices.deviceExists = function(service, id){
+    return IoTScapeDevices.getDevices(service).includes(id);
+};
+
+/**
+ * Clear the encryption settings for a device
+ * @param {String} service Name of service
+ * @param {String} id ID of device
+ */
+IoTScapeDevices.clearEncryption = function(service, id){
+    if(Object.keys(IoTScapeDevices._encryptionStates).includes(service)){
+        delete IoTScapeDevices._encryptionStates[service][id];
+    }
+};
+
+/**
+ * Set targetService's device with targetId as its ID to use the encryption settings of a different device
+ * @param {String} service Name of service
+ * @param {String} id ID of device
+ * @param {String} targetService 
+ * @param {String} targetId 
+ */
+IoTScapeDevices.link = function(service, id, targetService, targetId){
+    // Validate input
+    if(service == targetService && id == targetId){
+        throw new Error('Device cannot be linked to self');
+    }
+
+    // Prevent cycles and long chains by enforcing only one layer of linking
+    if(IoTScapeDevices.getEncryptionState(service, id).cipher == 'linked'){
+        throw new Error('Cannot link to other linked device');
+    }
+
+    IoTScapeDevices.updateEncryptionState(targetService, targetId, {service, id}, 'linked');
+};
+
+module.exports = IoTScapeDevices;

--- a/src/procedures/iotscape/iotscape-devices.js
+++ b/src/procedures/iotscape/iotscape-devices.js
@@ -115,7 +115,10 @@ IoTScapeDevices.updateEncryptionState = function (
   if (key != null) {
     IoTScapeDevices._setKey(service, id, key, cipher);
 
-    if (key != [0] && IoTScapeDevices._encryptionStates[service][id].cipher == "plain") {
+    if (
+      key != [0] &&
+      IoTScapeDevices._encryptionStates[service][id].cipher == "plain"
+    ) {
       cipher = "caesar";
     }
   }

--- a/src/procedures/iotscape/iotscape-devices.js
+++ b/src/procedures/iotscape/iotscape-devices.js
@@ -66,6 +66,9 @@ IoTScapeDevices.getEncryptionState = function (service, id) {
     IoTScapeDevices._encryptionStates[service][id] = {
       key: [0],
       cipher: "plain",
+      seqNum: null,
+      clientRate: null,
+      totalRate: null,
     };
   }
 

--- a/src/procedures/iotscape/iotscape-devices.js
+++ b/src/procedures/iotscape/iotscape-devices.js
@@ -205,41 +205,41 @@ IoTScapeDevices.updateEncryptionState = function (
   if (clientRate != null) {
     // Parse client rate
     if (clientRate instanceof String || typeof clientRate === "string") {
-        clientRate = parseInt(clientRate);
+      clientRate = parseInt(clientRate);
     }
 
     if (clientRate >= 0) {
       IoTScapeDevices._encryptionStates[service][id].clientRate = clientRate;
     } else {
-        throw new Error("Invalid client rate");
+      throw new Error("Invalid client rate");
     }
   }
 
   if (penalty != null) {
     // Parse penalty
     if (penalty instanceof String || typeof penalty === "string") {
-        penalty = parseInt(penalty);
+      penalty = parseInt(penalty);
     }
 
     if (penalty >= 0) {
       IoTScapeDevices._encryptionStates[service][id].clientPenalty = penalty;
     } else {
-        throw new Error("Invalid penalty");
+      throw new Error("Invalid penalty");
     }
   }
 
   if (totalRate != null) {
     // Parse total rate
     if (totalRate instanceof String || typeof totalRate === "string") {
-        totalRate = parseInt(totalRate);
+      totalRate = parseInt(totalRate);
     }
 
     if (totalRate >= 0) {
       IoTScapeDevices._encryptionStates[service][id].totalRate = totalRate;
     } else {
-        throw new Error("Invalid total rate");
+      throw new Error("Invalid total rate");
     }
-  }  
+  }
 };
 
 IoTScapeDevices._setKey = function (service, id, key, cipher) {

--- a/src/procedures/iotscape/iotscape-devices.js
+++ b/src/procedures/iotscape/iotscape-devices.js
@@ -91,6 +91,7 @@ IoTScapeDevices.updateEncryptionState = function (
   key = null,
   cipher = null,
 ) {
+  logger.log(`Updating encryption state for ${service}:${id}`);
   if (!IoTScapeDevices.deviceExists(service, id)) {
     throw new Error("Device not found");
   }
@@ -110,10 +111,15 @@ IoTScapeDevices.updateEncryptionState = function (
   // Update key if requested
   if (key != null) {
     IoTScapeDevices._setKey(service, id, key, cipher);
+
+    if (key != [0] && IoTScapeDevices._encryptionStates[service][id].cipher == "plain") {
+      cipher = "caesar";
+    }
   }
 
   // Update cipher if requested
   cipher = (cipher || "").toLowerCase();
+
   if (["linked", ...Object.keys(ciphers)].includes(cipher)) {
     IoTScapeDevices._encryptionStates[service][id].cipher = cipher;
   } else if (cipher != "") {

--- a/src/procedures/iotscape/iotscape-devices.js
+++ b/src/procedures/iotscape/iotscape-devices.js
@@ -70,7 +70,7 @@ IoTScapeDevices.getEncryptionState = function (service, id) {
       totalRate: 0, // in messages per second
       clientRate: 0, // in messages per second
       clientPenalty: 0, // in seconds
-      totalCount: 0, 
+      totalCount: 0,
       clientCounts: {},
     };
   }
@@ -93,45 +93,48 @@ IoTScapeDevices.getEncryptionState = function (service, id) {
  * @returns {Boolean} If message should be accepted
  */
 IoTScapeDevices.accepts = function (service, id, clientId, seqNum = -1) {
-    const state = IoTScapeDevices.getEncryptionState(service, id);
-    
-    // Check sequence number
-    if (state.lastSeqNum >= 0 && (seqNum <= state.lastSeqNum ||  seqNum > state.lastSeqNum + 100)) {
-        return false;
-    } else if (seqNum > -1) {
-        state.lastSeqNum = seqNum;
-    }
+  const state = IoTScapeDevices.getEncryptionState(service, id);
 
-    let client = state.clientCounts[clientId];
-    if (!client) {
-        client = {
-            count: 0,
-            penalty: 0,
-        };
-        state.clientCounts[clientId] = client;
-    }
+  // Check sequence number
+  if (
+    state.lastSeqNum >= 0 &&
+    (seqNum <= state.lastSeqNum || seqNum > state.lastSeqNum + 100)
+  ) {
+    return false;
+  } else if (seqNum > -1) {
+    state.lastSeqNum = seqNum;
+  }
 
-    if (client.penalty > 0) {
-        return false;
-    }
-
-    // Check rate limits
-    if (this.clientRate > 0 && client.count + 1 > this.clientRate) {
-        client.penalty = 1 + state.clientPenalty;
-        return false;
-    }
-
-    if (this.totalRate > 0 && state.totalCount + 1 > state.totalRate) {
-        return false;
-    }
-
-    state.totalCount += 1;
-    client.count += 1;
+  let client = state.clientCounts[clientId];
+  if (!client) {
+    client = {
+      count: 0,
+      penalty: 0,
+    };
     state.clientCounts[clientId] = client;
-    IoTScapeDevices._encryptionStates[service][id] = state;
+  }
 
-    logger.log(JSON.stringify(IoTScapeDevices._encryptionStates[service][id]));
-    return true;
+  if (client.penalty > 0) {
+    return false;
+  }
+
+  // Check rate limits
+  if (this.clientRate > 0 && client.count + 1 > this.clientRate) {
+    client.penalty = 1 + state.clientPenalty;
+    return false;
+  }
+
+  if (this.totalRate > 0 && state.totalCount + 1 > state.totalRate) {
+    return false;
+  }
+
+  state.totalCount += 1;
+  client.count += 1;
+  state.clientCounts[clientId] = client;
+  IoTScapeDevices._encryptionStates[service][id] = state;
+
+  logger.log(JSON.stringify(IoTScapeDevices._encryptionStates[service][id]));
+  return true;
 };
 
 /**
@@ -290,22 +293,22 @@ IoTScapeDevices.link = function (service, id, targetService, targetId) {
 
 // Clear rates every second
 setInterval(() => {
-    for (let service in IoTScapeDevices._encryptionStates) {
-        for (let id in IoTScapeDevices._encryptionStates[service]) {
-            let state = IoTScapeDevices._encryptionStates[service][id];
-            
-            state.totalCount = 0;
+  for (let service in IoTScapeDevices._encryptionStates) {
+    for (let id in IoTScapeDevices._encryptionStates[service]) {
+      let state = IoTScapeDevices._encryptionStates[service][id];
 
-            for (let clientId in state.clientCounts) {
-                let client = state.clientCounts[clientId];
-                client.count = 0;
-                client.penalty = Math.max(0, client.penalty - 1);
-                state.clientCounts[clientId] = client;
-            }
+      state.totalCount = 0;
 
-            IoTScapeDevices._encryptionStates[service][id] = state;
-        }
+      for (let clientId in state.clientCounts) {
+        let client = state.clientCounts[clientId];
+        client.count = 0;
+        client.penalty = Math.max(0, client.penalty - 1);
+        state.clientCounts[clientId] = client;
+      }
+
+      IoTScapeDevices._encryptionStates[service][id] = state;
     }
+  }
 }, 1000);
 
 module.exports = IoTScapeDevices;

--- a/src/procedures/iotscape/iotscape-devices.js
+++ b/src/procedures/iotscape/iotscape-devices.js
@@ -1,5 +1,5 @@
-const logger = require('../utils/logger')('iotscape-devices');
-const ciphers = require('../roboscape/ciphers');
+const logger = require("../utils/logger")("iotscape-devices");
+const ciphers = require("../roboscape/ciphers");
 
 /**
  * Stores information about registered devices, with a list of IDs and their respective hosts
@@ -15,9 +15,12 @@ IoTScapeDevices._encryptionStates = {};
  * @param {String} plaintext Plaintext to encrypt
  * @returns Plaintext encrypted with device's encryption settings
  */
-IoTScapeDevices.deviceEncrypt = function(service, id, plaintext){
-    let encryptionState = IoTScapeDevices.getEncryptionState(service, id);
-    return ciphers[encryptionState.cipher].encrypt(plaintext, encryptionState.key);
+IoTScapeDevices.deviceEncrypt = function (service, id, plaintext) {
+  let encryptionState = IoTScapeDevices.getEncryptionState(service, id);
+  return ciphers[encryptionState.cipher].encrypt(
+    plaintext,
+    encryptionState.key,
+  );
 };
 
 /**
@@ -27,9 +30,12 @@ IoTScapeDevices.deviceEncrypt = function(service, id, plaintext){
  * @param {String} ciphertext Ciphertext to decrypt
  * @returns Ciphertext decrypted with device's encryption settings
  */
-IoTScapeDevices.deviceDecrypt = function(service, id, ciphertext){
-    let encryptionState = IoTScapeDevices.getEncryptionState(service, id);
-    return ciphers[encryptionState.cipher].decrypt(ciphertext, encryptionState.key);
+IoTScapeDevices.deviceDecrypt = function (service, id, ciphertext) {
+  let encryptionState = IoTScapeDevices.getEncryptionState(service, id);
+  return ciphers[encryptionState.cipher].decrypt(
+    ciphertext,
+    encryptionState.key,
+  );
 };
 
 /**
@@ -37,8 +43,8 @@ IoTScapeDevices.deviceDecrypt = function(service, id, ciphertext){
  * @param {String} service Name of service
  * @param {String} id ID of device
  */
-IoTScapeDevices.getInfo = function(service, id){
-    return IoTScapeDevices._services[service][id];
+IoTScapeDevices.getInfo = function (service, id) {
+  return IoTScapeDevices._services[service][id];
 };
 
 /**
@@ -46,32 +52,31 @@ IoTScapeDevices.getInfo = function(service, id){
  * @param {String} service Service device is contained in
  * @param {String} id ID of device to get encryption settings for
  */
-IoTScapeDevices.getEncryptionState = function(service, id){
-    if(!IoTScapeDevices.deviceExists(service, id)){
-        throw new Error('Device not found');
-    }
+IoTScapeDevices.getEncryptionState = function (service, id) {
+  if (!IoTScapeDevices.deviceExists(service, id)) {
+    throw new Error("Device not found");
+  }
 
-    if(!Object.keys(IoTScapeDevices._encryptionStates).includes(service)){
-        IoTScapeDevices._encryptionStates[service] = {};
-    }
+  if (!Object.keys(IoTScapeDevices._encryptionStates).includes(service)) {
+    IoTScapeDevices._encryptionStates[service] = {};
+  }
 
-    if(!Object.keys(IoTScapeDevices._encryptionStates[service]).includes(id)){
-        // Create entry with default
-        IoTScapeDevices._encryptionStates[service][id] = {
-            key: [0],
-            cipher: 'plain'
-        };
-    }
+  if (!Object.keys(IoTScapeDevices._encryptionStates[service]).includes(id)) {
+    // Create entry with default
+    IoTScapeDevices._encryptionStates[service][id] = {
+      key: [0],
+      cipher: "plain",
+    };
+  }
 
-    const state = IoTScapeDevices._encryptionStates[service][id];
+  const state = IoTScapeDevices._encryptionStates[service][id];
 
-    if(state.cipher == 'linked'){
-        return IoTScapeDevices.getEncryptionState(state.key.service, state.key.id);
-    }
+  if (state.cipher == "linked") {
+    return IoTScapeDevices.getEncryptionState(state.key.service, state.key.id);
+  }
 
-    return state;
+  return state;
 };
-
 
 /**
  * Updates encryption settings for a device
@@ -80,54 +85,62 @@ IoTScapeDevices.getEncryptionState = function(service, id){
  * @param {String=} key Key to set
  * @param {String=} cipher Cipher to set
  */
-IoTScapeDevices.updateEncryptionState = function(service, id, key = null, cipher = null) {
-    if(!IoTScapeDevices.deviceExists(service, id)){
-        throw new Error('Device not found');
-    }
+IoTScapeDevices.updateEncryptionState = function (
+  service,
+  id,
+  key = null,
+  cipher = null,
+) {
+  if (!IoTScapeDevices.deviceExists(service, id)) {
+    throw new Error("Device not found");
+  }
 
-    if(!Object.keys(IoTScapeDevices._encryptionStates).includes(service)){
-        IoTScapeDevices._encryptionStates[service] = {};
-    }
+  if (!Object.keys(IoTScapeDevices._encryptionStates).includes(service)) {
+    IoTScapeDevices._encryptionStates[service] = {};
+  }
 
-    if(!Object.keys(IoTScapeDevices._encryptionStates[service]).includes(id)){
-        // Create entry with default
-        IoTScapeDevices._encryptionStates[service][id] = {
-            key: [0],
-            cipher: 'plain'
-        };
-    }
+  if (!Object.keys(IoTScapeDevices._encryptionStates[service]).includes(id)) {
+    // Create entry with default
+    IoTScapeDevices._encryptionStates[service][id] = {
+      key: [0],
+      cipher: "plain",
+    };
+  }
 
-    // Update key if requested
-    if(key != null){
-        IoTScapeDevices._setKey(service, id, key, cipher);
-    }
+  // Update key if requested
+  if (key != null) {
+    IoTScapeDevices._setKey(service, id, key, cipher);
+  }
 
-    // Update cipher if requested
-    cipher = (cipher || '').toLowerCase();
-    if(['linked', ...Object.keys(ciphers)].includes(cipher)){
-        IoTScapeDevices._encryptionStates[service][id].cipher = cipher;
-    } else if(cipher != ''){
-        // Prevent attempts to use ciphers with no implementation
-        throw new Error('Invalid cipher');
-    }
+  // Update cipher if requested
+  cipher = (cipher || "").toLowerCase();
+  if (["linked", ...Object.keys(ciphers)].includes(cipher)) {
+    IoTScapeDevices._encryptionStates[service][id].cipher = cipher;
+  } else if (cipher != "") {
+    // Prevent attempts to use ciphers with no implementation
+    throw new Error("Invalid cipher");
+  }
 };
 
-IoTScapeDevices._setKey = function(service, id, key, cipher){
-    // Set default cipher
-    if(IoTScapeDevices._encryptionStates[service][id].cipher === 'plain' && cipher == null){
-        cipher = 'caesar';
+IoTScapeDevices._setKey = function (service, id, key, cipher) {
+  // Set default cipher
+  if (
+    IoTScapeDevices._encryptionStates[service][id].cipher === "plain" &&
+    cipher == null
+  ) {
+    cipher = "caesar";
+  }
+
+  // Setting linked status does not require key to be parsed
+  if (cipher != "linked") {
+    key = key.map((c) => parseInt(c));
+
+    if (key.includes(NaN)) {
+      throw new Error("Invalid key");
     }
+  }
 
-    // Setting linked status does not require key to be parsed
-    if(cipher != 'linked'){
-        key = key.map(c => parseInt(c));        
-
-        if(key.includes(NaN)){
-            throw new Error('Invalid key');
-        }
-    }
-
-    IoTScapeDevices._encryptionStates[service][id].key = key;
+  IoTScapeDevices._encryptionStates[service][id].key = key;
 };
 
 /**
@@ -135,22 +148,25 @@ IoTScapeDevices._setKey = function(service, id, key, cipher){
  * @param {String} service Name of service
  * @param {String} id ID of device to remove
  */
-IoTScapeDevices.removeDevice = function(service, id) {
-    if(!IoTScapeDevices.deviceExists(service, id)){
-        return;
-    }
+IoTScapeDevices.removeDevice = function (service, id) {
+  if (!IoTScapeDevices.deviceExists(service, id)) {
+    return;
+  }
 
-    delete IoTScapeDevices._services[service][id];
+  delete IoTScapeDevices._services[service][id];
 
-    if(Object.keys(IoTScapeDevices._encryptionStates).includes(service)){
-        delete IoTScapeDevices._encryptionStates[service][id];
-    }
+  if (Object.keys(IoTScapeDevices._encryptionStates).includes(service)) {
+    delete IoTScapeDevices._encryptionStates[service][id];
+  }
 
-    if(IoTScapeDevices._listeningClients[service] !== undefined && IoTScapeDevices._listeningClients[service][id] !== undefined){
-        delete IoTScapeDevices._listeningClients[service][id];
-    }
+  if (
+    IoTScapeDevices._listeningClients[service] !== undefined &&
+    IoTScapeDevices._listeningClients[service][id] !== undefined
+  ) {
+    delete IoTScapeDevices._listeningClients[service][id];
+  }
 
-    logger.log(`Removed ${service}:${id}`);
+  logger.log(`Removed ${service}:${id}`);
 };
 
 /**
@@ -158,8 +174,8 @@ IoTScapeDevices.removeDevice = function(service, id) {
  * @param {String} service Name of service to get device IDs for
  */
 IoTScapeDevices.getDevices = function (service) {
-    const serviceDict = IoTScapeDevices._services[service];
-    return Object.keys(serviceDict || []);
+  const serviceDict = IoTScapeDevices._services[service];
+  return Object.keys(serviceDict || []);
 };
 
 /**
@@ -168,8 +184,8 @@ IoTScapeDevices.getDevices = function (service) {
  * @param {String} id ID of device
  * @returns {Boolean} If device exists
  */
-IoTScapeDevices.deviceExists = function(service, id){
-    return IoTScapeDevices.getDevices(service).includes(id);
+IoTScapeDevices.deviceExists = function (service, id) {
+  return IoTScapeDevices.getDevices(service).includes(id);
 };
 
 /**
@@ -177,31 +193,34 @@ IoTScapeDevices.deviceExists = function(service, id){
  * @param {String} service Name of service
  * @param {String} id ID of device
  */
-IoTScapeDevices.clearEncryption = function(service, id){
-    if(Object.keys(IoTScapeDevices._encryptionStates).includes(service)){
-        delete IoTScapeDevices._encryptionStates[service][id];
-    }
+IoTScapeDevices.clearEncryption = function (service, id) {
+  if (Object.keys(IoTScapeDevices._encryptionStates).includes(service)) {
+    delete IoTScapeDevices._encryptionStates[service][id];
+  }
 };
 
 /**
  * Set targetService's device with targetId as its ID to use the encryption settings of a different device
  * @param {String} service Name of service
  * @param {String} id ID of device
- * @param {String} targetService 
- * @param {String} targetId 
+ * @param {String} targetService
+ * @param {String} targetId
  */
-IoTScapeDevices.link = function(service, id, targetService, targetId){
-    // Validate input
-    if(service == targetService && id == targetId){
-        throw new Error('Device cannot be linked to self');
-    }
+IoTScapeDevices.link = function (service, id, targetService, targetId) {
+  // Validate input
+  if (service == targetService && id == targetId) {
+    throw new Error("Device cannot be linked to self");
+  }
 
-    // Prevent cycles and long chains by enforcing only one layer of linking
-    if(IoTScapeDevices.getEncryptionState(service, id).cipher == 'linked'){
-        throw new Error('Cannot link to other linked device');
-    }
+  // Prevent cycles and long chains by enforcing only one layer of linking
+  if (IoTScapeDevices.getEncryptionState(service, id).cipher == "linked") {
+    throw new Error("Cannot link to other linked device");
+  }
 
-    IoTScapeDevices.updateEncryptionState(targetService, targetId, {service, id}, 'linked');
+  IoTScapeDevices.updateEncryptionState(targetService, targetId, {
+    service,
+    id,
+  }, "linked");
 };
 
 module.exports = IoTScapeDevices;

--- a/src/procedures/iotscape/iotscape-devices.js
+++ b/src/procedures/iotscape/iotscape-devices.js
@@ -133,7 +133,6 @@ IoTScapeDevices.accepts = function (service, id, clientId, seqNum = -1) {
   state.clientCounts[clientId] = client;
   IoTScapeDevices._encryptionStates[service][id] = state;
 
-  logger.log(JSON.stringify(IoTScapeDevices._encryptionStates[service][id]));
   return true;
 };
 

--- a/src/procedures/iotscape/iotscape-services.js
+++ b/src/procedures/iotscape/iotscape-services.js
@@ -550,13 +550,14 @@ IoTScapeServices.sendMessageToListeningClients = function (
   if (IoTScapeDevices.getEncryptionState(service, id).cipher == "plain") {
     // Send basic mode responses
     clients.forEach((client) => {
-      client.sendMessage(type, { id, ...content });
+      client.sendMessage(type, { service, id, ...content });
     });
   }
 
   if (type !== "device command") {
     clients.forEach((client) => {
       client.sendMessage("device message", {
+        service,
         id,
         message: IoTScapeDevices.deviceEncrypt(
           service,

--- a/src/procedures/iotscape/iotscape-services.js
+++ b/src/procedures/iotscape/iotscape-services.js
@@ -1,12 +1,12 @@
 const logger = require("../utils/logger")("iotscape-services");
 const { setTimeout, setInterval } = require("../../timers");
+const IoTScapeDevices = require('./iotscape-devices');
 
 /**
  * Stores information about registered services, with a list of IDs and their respective hosts
  */
 const IoTScapeServices = {};
 
-IoTScapeServices._services = {};
 IoTScapeServices._serviceDefinitions = {};
 
 /**
@@ -21,7 +21,7 @@ IoTScapeServices.updateOrCreateServiceInfo = function (
   id,
   rinfo,
 ) {
-  let service = IoTScapeServices._services[name];
+  let service = IoTScapeDevices._services[name];
   IoTScapeServices._serviceDefinitions[name] = definition;
 
   logger.log(
@@ -31,46 +31,17 @@ IoTScapeServices.updateOrCreateServiceInfo = function (
 
   if (!service) {
     // Service not added yet
-    service = IoTScapeServices._services[name] = {};
+    service = IoTScapeDevices._services[name] = {};
   }
 
   service[id] = rinfo;
 };
 
 /**
- * Remove a device from a service
- * @param {String} service Name of service
- * @param {String} id ID of device to remove
- */
-IoTScapeServices.removeDevice = function (service, id) {
-  if (!IoTScapeServices.deviceExists(service, id)) {
-    return;
-  }
-
-  delete IoTScapeServices._services[service][id];
-
-  if (
-    IoTScapeServices._listeningClients[service] !== undefined &&
-    IoTScapeServices._listeningClients[service][id] !== undefined
-  ) {
-    delete IoTScapeServices._listeningClients[service][id];
-  }
-};
-
-/**
- * List IDs of devices associated for a service
- * @param {String} service Name of service to get device IDs for
- */
-IoTScapeServices.getDevices = function (service) {
-  const serviceDict = IoTScapeServices._services[service];
-  return Object.keys(serviceDict || []);
-};
-
-/**
  * List services
  */
 IoTScapeServices.getServices = function () {
-  return Object.keys(IoTScapeServices._services);
+  return Object.keys(IoTScapeDevices._services);
 };
 
 /**
@@ -79,25 +50,15 @@ IoTScapeServices.getServices = function () {
  */
 IoTScapeServices.getMessageTypes = function (service) {
   if (!IoTScapeServices.serviceExists(service)) {
-    return [];
+    return {};
   }
 
   // Parse events into NetsBlox-friendlier format
-  let eventsInfo = IoTScapeServices._serviceDefinitions[service].events;
+  let eventsInfo = IoTScapeServices._serviceDefinitions[service].events || {};
   eventsInfo = Object.keys(eventsInfo).map(
-    (event) => [event, eventsInfo[event].params],
+    (event) => [event, ['id', ...eventsInfo[event].params]],
   );
   return eventsInfo;
-};
-
-/**
- * Determine if a device with a given ID exists
- * @param {String} service Name of service
- * @param {String} id ID of device
- * @returns {Boolean} If device exists
- */
-IoTScapeServices.deviceExists = function (service, id) {
-  return IoTScapeServices.getDevices(service).includes(id);
 };
 
 /**
@@ -107,6 +68,41 @@ IoTScapeServices.deviceExists = function (service, id) {
  */
 IoTScapeServices.serviceExists = function (service) {
   return IoTScapeServices.getServices().includes(service);
+};
+
+IoTScapeServices._specialMethods = {
+  'heartbeat': {
+      returns: {
+          type:['boolean']
+      }
+  },
+  'setKey': {
+      params: [{
+          'name': 'key',
+          'documentation': 'Key to set',
+          'type': 'number',
+          'optional': false
+      }],
+      returns: {
+          type: ['void']
+      }
+  },
+  'setCipher': {
+      params: [{
+          'name': 'cipher',
+          'documentation': 'Cipher to use',
+          'type': 'string',
+          'optional': false
+      }],
+      returns: {
+          type:['void']
+      }
+  },
+  '_requestedKey': {
+      returns: {
+          type: ['void']
+      }
+  }
 };
 
 /**
@@ -120,17 +116,8 @@ IoTScapeServices.functionExists = function (service, func) {
     return false;
   }
 
-  return func === "heartbeat" ||
-    IoTScapeServices.getFunctionInfo(service, func) !== undefined;
-};
-
-/**
- * Get the remote host of a IoTScape device
- * @param {String} service Name of service
- * @param {String} id ID of device
- */
-IoTScapeServices.getInfo = function (service, id) {
-  return IoTScapeServices._services[service][id];
+  return Object.keys(IoTScapeServices._specialMethods).includes(func) 
+    || IoTScapeServices.getFunctionInfo(service, func) !== undefined;
 };
 
 /**
@@ -139,8 +126,8 @@ IoTScapeServices.getInfo = function (service, id) {
  * @param {String} func Name of function
  */
 IoTScapeServices.getFunctionInfo = function (service, func) {
-  if (func === "heartbeat") {
-    return { returns: { type: ["boolean"] } };
+  if(Object.keys(IoTScapeServices._specialMethods).includes(func)){
+    return IoTScapeServices._specialMethods[func];
   }
 
   return IoTScapeServices._serviceDefinitions[service].methods[func];
@@ -168,7 +155,7 @@ IoTScapeServices.listen = function (service, client, id) {
   id = id.toString();
 
   // Validate name and ID
-  if (!IoTScapeServices.deviceExists(service, id)) {
+  if (!IoTScapeDevices.deviceExists(service, id)) {
     return false;
   }
 
@@ -180,21 +167,19 @@ IoTScapeServices.listen = function (service, client, id) {
     IoTScapeServices._listeningClients[service][id] = [];
   }
 
-  // Prevent listen if this client is already listening
-  if (
-    IoTScapeServices._listeningClients[service][id].some((c) =>
-      c.clientId === client.clientId
+  // Prevent listen if this client/role/project combination is already listening
+  if (!IoTScapeServices._listeningClients[service][id].some((existingClient) =>
+      existingClient.clientId === client.clientId && existingClient.roleId == client.roleId && existingClient.projectId == client.projectId
     )
-  ) {
-    return;
+  ) {  
+    IoTScapeServices._listeningClients[service][id].push(client);
   }
-
-  IoTScapeServices._listeningClients[service][id].push(client);
 };
 
 /**
  * Make a call to a IoTScape function
  * @param {String} service Name of service
+ * @param {String} func RPC on device to call
  * @param {String} id ID of device
  * @param  {...any} args
  */
@@ -203,22 +188,43 @@ IoTScapeServices.call = async function (service, func, id, ...args) {
 
   // Validate name, ID, and function
   if (
-    !IoTScapeServices.deviceExists(service, id) ||
+    !IoTScapeDevices.deviceExists(service, id) ||
     !IoTScapeServices.functionExists(service, func)
   ) {
     return false;
   }
 
-  // Create and send request
-  const reqid = IoTScapeServices._generateRequestID();
-  let request = {
-    id: reqid,
-    service: service,
-    device: id,
-    function: func,
-    params: [...args],
-  };
+  // Don't send out serverside commands
+  if(func !== 'setKey' && func !== 'setCipher') {
+    // Create and send request
+    let request = {
+        id: reqid,
+        service: service,
+        device: id,
+        function: func, 
+        params: [...args],
+    };
 
+    const rinfo = IoTScapeDevices.getInfo(service, id);
+    IoTScapeServices.socket.send(JSON.stringify(request), rinfo.port, rinfo.address);
+  }
+
+  // Relay as message to listening clients
+  if(func !== 'heartbeat'){
+      IoTScapeServices.sendMessageToListeningClients(service, id, 'device command', {command: IoTScapeDevices.deviceEncrypt(service, id, [func, ...args].join(' '))});
+  }
+
+  // Handle setKey/Cipher after relaying message to use old encryption
+  if(IoTScapeDevices.getEncryptionState(service, id).cipher != 'linked'){
+      if(func === 'setKey'){
+          IoTScapeDevices.updateEncryptionState(service, id, args, null);
+      } else if(func === 'setCipher'){
+          IoTScapeDevices.updateEncryptionState(service, id, null, args[0]);
+      }
+  } else {
+    // Not supported on linked device
+    return false;
+  }
   // Determine response type
   const methodInfo = IoTScapeServices.getFunctionInfo(service, func);
   const responseType = methodInfo.returns.type;
@@ -274,70 +280,138 @@ IoTScapeServices.call = async function (service, func, id, ...args) {
   return promise;
 };
 
+/**
+ * Map of message types which should be handled on ther server to their handlers
+ */
+IoTScapeServices._specialMessageTypes = {
+  '_reset': (parsed) => {
+  // Reset encryption on device
+      logger.log(`Resetting ${parsed.service}:${parsed.id}`);
+      IoTScapeDevices.clearEncryption(parsed.service, parsed.id);
+  }, 
+  '_requestKey': (parsed) => {
+
+      if(IoTScapeDevices.getEncryptionState(parsed.service, parsed.id).cipher == 'linked'){
+          logger.log(`Refused to generate HW key for ${parsed.service}:${parsed.id} due to existing link`);
+          return;
+      }
+      // Generate hardware key
+      let key = [];
+
+      for (let i = 0; i < 4; i++) {
+          key.push(Math.floor(Math.random() * 16));
+      }
+
+      IoTScapeDevices.updateEncryptionState(parsed.service, parsed.id, key, 'caesar');
+
+      // Tell device what the new key is, so it can display it
+      IoTScapeServices.call(parsed.service, '_requestedKey', parsed.id, ...key);
+  }, 
+  '_link': (parsed) => {
+      const targetService = parsed.event.args.service;
+      const targetID = parsed.event.args.id;
+
+      if(!IoTScapeDevices.deviceExists(targetService, targetID)){
+          logger.log(`Requested invalid link of ${parsed.service}:${parsed.id} to ${targetService}:${targetID}`);
+          return;
+      }
+
+      logger.log(`Linking ${parsed.service}:${parsed.id} to ${targetService}:${targetID}`);
+
+      IoTScapeDevices.link(parsed.service, parsed.id, targetService, targetID);
+  }
+};
+
+const _handleMessage = function (message, remote) {
+  let parsed = null;
+
+  try {
+      parsed = JSON.parse(message);
+  } catch(err){
+      logger.log('Error parsing IoTScape message: ' + err);
+      return;
+  }
+
+  if(parsed == null){
+      logger.log('Invalid IoTScape message');
+      return;
+  }
+
+  // Ignore other messages
+  if(parsed.request){
+      _handleResponse(parsed);
+  }
+
+  if(parsed.event && IoTScapeDevices.deviceExists(parsed.service, parsed.id)){
+      _handleEvent(parsed, remote);
+  }
+};
+
+const _handleResponse = function(parsed){
+
+  const requestID = parsed.request;
+
+  if(Object.keys(IoTScapeServices._awaitingRequests).includes(requestID.toString())){
+      if(parsed.response){
+          // Return multiple results as a list, single result as a value
+          const methodInfo = IoTScapeServices.getFunctionInfo(IoTScapeServices._awaitingRequests[requestID].service, IoTScapeServices._awaitingRequests[requestID].function);
+          const responseType = methodInfo.returns.type;
+
+          try {
+              if(responseType.length > 1) {
+                  IoTScapeServices._awaitingRequests[requestID].resolve(parsed.response);
+              } else {
+                  IoTScapeServices._awaitingRequests[requestID].resolve(...parsed.response);
+              }
+          } catch (error) {
+              logger.log('IoTScape response invalid: ' + error);
+          }
+
+          delete IoTScapeServices._awaitingRequests[requestID];
+      }
+  }
+};
+
+const _handleEvent = function(parsed, remote) {
+  // Handle special message types, but only if they come from the device
+  if(Object.keys(IoTScapeServices._specialMessageTypes).includes(parsed.event.type) && IoTScapeDevices._services[parsed.service][parsed.id].address == remote.address && IoTScapeDevices._services[parsed.service][parsed.id].port == remote.port){
+      IoTScapeServices._specialMessageTypes[parsed.event.type](parsed);
+  } else {
+      IoTScapeServices.sendMessageToListeningClients(parsed.service, parsed.id.toString(), parsed.event.type, {...parsed.event.args});
+  }
+};
+
+/**
+ * Send a NetsBlox message to clients listening to a device
+ * @param {String} service Name of service
+ * @param {String} id ID of device
+ * @param {String} type Message type
+ * @param {Object} content Contents of message
+ */
+IoTScapeServices.sendMessageToListeningClients = function(service, id, type, content){
+  // Find listening clients 
+  const clientsByID = IoTScapeServices._listeningClients[service] || {};
+  const clients = clientsByID[id] || [];
+
+  if(IoTScapeDevices.getEncryptionState(service, id).cipher == 'plain'){
+      // Send basic mode responses
+      clients.forEach((client) => {
+          client.sendMessage(type, {id, ...content});
+      });
+  } 
+
+  if(type !== 'device command') {
+      clients.forEach((client) => {
+          client.sendMessage('device message', {id, message: IoTScapeDevices.deviceEncrypt(service, id, [type, ...Object.values(content)].join(' '))});
+      });
+  }
+};
+
 IoTScapeServices.start = function (socket) {
   IoTScapeServices.socket = socket;
 
   // Handle incoming responses
-  IoTScapeServices.socket.on("message", function (message) {
-    let parsed;
-
-    try {
-      parsed = JSON.parse(message);
-    } catch (err) {
-      logger.log("Error parsing IoTScape message: " + err);
-      return;
-    }
-
-    // Ignore other messages
-    if (!parsed.request) {
-      return;
-    }
-
-    const requestID = parsed.request;
-
-    if (
-      Object.keys(IoTScapeServices._awaitingRequests).includes(
-        requestID.toString(),
-      )
-    ) {
-      if (parsed.response) {
-        // Return multiple results as a list, single result as a value
-        const methodInfo = IoTScapeServices.getFunctionInfo(
-          IoTScapeServices._awaitingRequests[requestID].service,
-          IoTScapeServices._awaitingRequests[requestID].function,
-        );
-        const responseType = methodInfo.returns.type;
-
-        try {
-          if (responseType.length > 1) {
-            IoTScapeServices._awaitingRequests[requestID].resolve(
-              parsed.response,
-            );
-          } else {
-            IoTScapeServices._awaitingRequests[requestID].resolve(
-              ...parsed.response,
-            );
-          }
-        } catch (error) {
-          logger.log("IoTScape response invalid: " + error);
-        }
-
-        delete IoTScapeServices._awaitingRequests[requestID];
-      }
-    }
-
-    if (parsed.event) {
-      // Find listening clients
-      const clientsByID = IoTScapeServices._listeningClients[parsed.service] ||
-        {};
-      const clients = clientsByID[parsed.id.toString()] || [];
-
-      // Send responses
-      clients.forEach((client) => {
-        client.sendMessage(parsed.event.type, parsed.event.args);
-      });
-    }
-  });
+  IoTScapeServices.socket.on("message", _handleMessage);
 
   // Request heartbeats on interval
   async function heartbeat(service, device) {

--- a/src/procedures/iotscape/iotscape-services.js
+++ b/src/procedures/iotscape/iotscape-services.js
@@ -422,7 +422,13 @@ IoTScapeServices._specialMessageTypes = {
     );
 
     // Tell device what the new key is, so it can display it
-    IoTScapeServices.call(parsed.service, "_requestedKey", parsed.id, null, ...key);
+    IoTScapeServices.call(
+      parsed.service,
+      "_requestedKey",
+      parsed.id,
+      null,
+      ...key,
+    );
   },
   "_link": (parsed) => {
     const targetService = parsed.event.args.service;

--- a/src/procedures/iotscape/iotscape-services.js
+++ b/src/procedures/iotscape/iotscape-services.js
@@ -24,6 +24,11 @@ IoTScapeServices.updateOrCreateServiceInfo = function (
   let service = IoTScapeDevices._services[name];
   IoTScapeServices._serviceDefinitions[name] = definition;
 
+  if(!rinfo) {
+    logger.log("Service " + name + " created without connection info");
+    return;
+  }
+
   logger.log(
     "Discovering " + name + ":" + id + " at " + rinfo.address + ":" +
       rinfo.port,

--- a/src/procedures/iotscape/iotscape-services.js
+++ b/src/procedures/iotscape/iotscape-services.js
@@ -299,7 +299,7 @@ IoTScapeServices.call = async function (service, func, id, ...args) {
 };
 
 /**
- * Map of message types which should be handled on ther server to their handlers
+ * Map of message types which should be handled on the server to their handlers
  */
 IoTScapeServices._specialMessageTypes = {
   "_reset": (parsed) => {

--- a/src/procedures/iotscape/iotscape-services.js
+++ b/src/procedures/iotscape/iotscape-services.js
@@ -106,6 +106,21 @@ IoTScapeServices._specialMethods = {
 };
 
 /**
+ * List methods associated with a service
+ * @param {string} service Name of service
+ */
+IoTScapeServices.getMethods = function(service) {
+  if(!IoTScapeServices.serviceExists(service)){
+      return {};
+  }
+
+  // Parse methods into NetsBlox-friendlier format
+  let methodsInfo = IoTScapeServices._serviceDefinitions[service].methods;
+  methodsInfo = Object.keys(methodsInfo).map(method => [method, methodsInfo[method].params.map(param => param.name)]);
+  return methodsInfo;
+};
+
+/**
  * Determine if a service has a given function
  * @param {String} service Name of service
  * @param {String} func Name of function
@@ -196,6 +211,8 @@ IoTScapeServices.call = async function (service, func, id, ...args) {
   ) {
     return false;
   }
+  
+  const reqid = IoTScapeServices._generateRequestID();
 
   // Don't send out serverside commands
   if (func !== "setKey" && func !== "setCipher") {
@@ -495,14 +512,14 @@ IoTScapeServices.start = function (socket) {
 
   setInterval(async () => {
     for (const service of IoTScapeServices.getServices()) {
-      IoTScapeServices.getDevices(service).forEach(async (device) => {
+      IoTScapeDevices.getDevices(service).forEach(async (device) => {
         if (!(await heartbeat(service, device))) {
           // Send second heartbeat request, will timeout if device does not respond
           if (!(await heartbeat(service, device))) {
             logger.log(
               `${service}:${device} did not respond to heartbeat, removing from active devices`,
             );
-            IoTScapeServices.removeDevice(service, device);
+            IoTScapeDevices.removeDevice(service, device);
           }
         }
       });

--- a/src/procedures/iotscape/iotscape-services.js
+++ b/src/procedures/iotscape/iotscape-services.js
@@ -185,7 +185,9 @@ IoTScapeServices.getFunctionInfo = function (service, func) {
     return IoTScapeServices._specialMethods[func];
   }
 
-  let method = (IoTScapeServices._serviceDefinitions[service] ?? {methods: []}).methods.filter(m => m.name === func);
+  let method =
+    (IoTScapeServices._serviceDefinitions[service] ?? { methods: [] }).methods
+      .filter((m) => m.name === func);
   return method.length > 0 ? method[0] : undefined;
 };
 

--- a/src/procedures/iotscape/iotscape-services.js
+++ b/src/procedures/iotscape/iotscape-services.js
@@ -288,11 +288,34 @@ IoTScapeServices.call = async function (service, func, id, ...args) {
         } else if (func === "setCipher") {
           IoTScapeDevices.updateEncryptionState(service, id, null, args[0]);
         } else if (func === "setClientRate") {
-          IoTScapeDevices.updateEncryptionState(service, id, null, null, args[0], args[1]);
+          IoTScapeDevices.updateEncryptionState(
+            service,
+            id,
+            null,
+            null,
+            args[0],
+            args[1],
+          );
         } else if (func === "setTotalRate") {
-          IoTScapeDevices.updateEncryptionState(service, id, null, null, null, null, args[0]);
+          IoTScapeDevices.updateEncryptionState(
+            service,
+            id,
+            null,
+            null,
+            null,
+            null,
+            args[0],
+          );
         } else if (func === "resetRate") {
-          IoTScapeDevices.updateEncryptionState(service, id, null, null, 0, 0, 0);
+          IoTScapeDevices.updateEncryptionState(
+            service,
+            id,
+            null,
+            null,
+            0,
+            0,
+            0,
+          );
         }
       } else {
         // Not supported on linked device

--- a/src/procedures/iotscape/iotscape-services.js
+++ b/src/procedures/iotscape/iotscape-services.js
@@ -104,8 +104,7 @@ IoTScapeServices._specialMethods = {
       "documentation": "Maximum number of messages per second per client",
       "type": "number",
       "optional": false,
-    },
-    {
+    }, {
       "name": "penalty",
       "documentation": "Penalty for exceeding rate limit in seconds",
       "type": "number",
@@ -121,7 +120,7 @@ IoTScapeServices._specialMethods = {
       "documentation": "Maximum number of messages per second for all clients",
       "type": "number",
       "optional": false,
-    },],
+    }],
     returns: {
       type: ["void"],
     },
@@ -278,7 +277,10 @@ IoTScapeServices.call = async function (service, func, id, ...args) {
     );
 
     // Handle special functions
-    if (func == "setKey" || func == "setCipher" || func == "setClientRate" || func == "setTotalRate" || func == "resetRate" ) {
+    if (
+      func == "setKey" || func == "setCipher" || func == "setClientRate" ||
+      func == "setTotalRate" || func == "resetRate"
+    ) {
       // Handle setKey/Cipher after relaying message to use old encryption
       if (IoTScapeDevices.getEncryptionState(service, id).cipher != "linked") {
         if (func === "setKey") {
@@ -286,11 +288,8 @@ IoTScapeServices.call = async function (service, func, id, ...args) {
         } else if (func === "setCipher") {
           IoTScapeDevices.updateEncryptionState(service, id, null, args[0]);
         } else if (func === "setClientRate") {
-
         } else if (func === "setTotalRate") {
-
         } else if (func === "resetRate") {
-
         }
       } else {
         // Not supported on linked device

--- a/src/procedures/iotscape/iotscape-services.js
+++ b/src/procedures/iotscape/iotscape-services.js
@@ -24,7 +24,12 @@ IoTScapeServices.updateOrCreateServiceInfo = function (
   let service = IoTScapeDevices._services[name];
   IoTScapeServices._serviceDefinitions[name] = definition;
 
-  if(!rinfo) {
+  if (!service) {
+    // Service not added yet
+    service = IoTScapeDevices._services[name] = {};
+  }
+
+  if (!rinfo) {
     logger.log("Service " + name + " created without connection info");
     return;
   }
@@ -33,11 +38,6 @@ IoTScapeServices.updateOrCreateServiceInfo = function (
     "Discovering " + name + ":" + id + " at " + rinfo.address + ":" +
       rinfo.port,
   );
-
-  if (!service) {
-    // Service not added yet
-    service = IoTScapeDevices._services[name] = {};
-  }
 
   service[id] = rinfo;
 };

--- a/src/procedures/iotscape/iotscape-services.js
+++ b/src/procedures/iotscape/iotscape-services.js
@@ -109,14 +109,16 @@ IoTScapeServices._specialMethods = {
  * List methods associated with a service
  * @param {string} service Name of service
  */
-IoTScapeServices.getMethods = function(service) {
-  if(!IoTScapeServices.serviceExists(service)){
-      return {};
+IoTScapeServices.getMethods = function (service) {
+  if (!IoTScapeServices.serviceExists(service)) {
+    return {};
   }
 
   // Parse methods into NetsBlox-friendlier format
   let methodsInfo = IoTScapeServices._serviceDefinitions[service].methods;
-  methodsInfo = Object.keys(methodsInfo).map(method => [method, methodsInfo[method].params.map(param => param.name)]);
+  methodsInfo = Object.keys(methodsInfo).map(
+    (method) => [method, methodsInfo[method].params.map((param) => param.name)],
+  );
   return methodsInfo;
 };
 
@@ -211,7 +213,7 @@ IoTScapeServices.call = async function (service, func, id, ...args) {
   ) {
     return false;
   }
-  
+
   const reqid = IoTScapeServices._generateRequestID();
 
   // Don't send out serverside commands

--- a/src/procedures/iotscape/iotscape-services.js
+++ b/src/procedures/iotscape/iotscape-services.js
@@ -288,8 +288,11 @@ IoTScapeServices.call = async function (service, func, id, ...args) {
         } else if (func === "setCipher") {
           IoTScapeDevices.updateEncryptionState(service, id, null, args[0]);
         } else if (func === "setClientRate") {
+          IoTScapeDevices.updateEncryptionState(service, id, null, null, args[0], args[1]);
         } else if (func === "setTotalRate") {
+          IoTScapeDevices.updateEncryptionState(service, id, null, null, null, null, args[0]);
         } else if (func === "resetRate") {
+          IoTScapeDevices.updateEncryptionState(service, id, null, null, 0, 0, 0);
         }
       } else {
         // Not supported on linked device

--- a/src/procedures/iotscape/iotscape-services.js
+++ b/src/procedures/iotscape/iotscape-services.js
@@ -185,7 +185,8 @@ IoTScapeServices.getFunctionInfo = function (service, func) {
     return IoTScapeServices._specialMethods[func];
   }
 
-  return IoTScapeServices._serviceDefinitions[service].methods[func];
+  let method = (IoTScapeServices._serviceDefinitions[service] ?? {methods: []}).methods.filter(m => m.name === func);
+  return method.length > 0 ? method[0] : undefined;
 };
 
 IoTScapeServices._lastRequestID = 0;
@@ -250,6 +251,13 @@ IoTScapeServices.call = async function (service, func, id, clientId, ...args) {
     !IoTScapeDevices.deviceExists(service, id) ||
     !IoTScapeServices.functionExists(service, func)
   ) {
+    if (!IoTScapeDevices.deviceExists(service, id)) {
+      logger.log("Device does not exist");
+    }
+    if (!IoTScapeServices.functionExists(service, func)) {
+      logger.log("Function does not exist");
+    }
+
     return false;
   }
 

--- a/src/procedures/iotscape/iotscape-services.js
+++ b/src/procedures/iotscape/iotscape-services.js
@@ -98,6 +98,40 @@ IoTScapeServices._specialMethods = {
       type: ["void"],
     },
   },
+  "setClientRate": {
+    params: [{
+      "name": "rate",
+      "documentation": "Maximum number of messages per second per client",
+      "type": "number",
+      "optional": false,
+    },
+    {
+      "name": "penalty",
+      "documentation": "Penalty for exceeding rate limit in seconds",
+      "type": "number",
+      "optional": false,
+    }],
+    returns: {
+      type: ["void"],
+    },
+  },
+  "setTotalRate": {
+    params: [{
+      "name": "rate",
+      "documentation": "Maximum number of messages per second for all clients",
+      "type": "number",
+      "optional": false,
+    },],
+    returns: {
+      type: ["void"],
+    },
+  },
+  "resetRate": {
+    params: [],
+    returns: {
+      type: ["void"],
+    },
+  },
   "_requestedKey": {
     returns: {
       type: ["void"],
@@ -244,20 +278,26 @@ IoTScapeServices.call = async function (service, func, id, ...args) {
     );
 
     // Handle special functions
-    if (func == "setKey" || func == "setCipher") {
+    if (func == "setKey" || func == "setCipher" || func == "setClientRate" || func == "setTotalRate" || func == "resetRate" ) {
       // Handle setKey/Cipher after relaying message to use old encryption
       if (IoTScapeDevices.getEncryptionState(service, id).cipher != "linked") {
         if (func === "setKey") {
           IoTScapeDevices.updateEncryptionState(service, id, args, null);
         } else if (func === "setCipher") {
           IoTScapeDevices.updateEncryptionState(service, id, null, args[0]);
-        }
+        } else if (func === "setClientRate") {
 
-        return true;
+        } else if (func === "setTotalRate") {
+
+        } else if (func === "resetRate") {
+
+        }
       } else {
         // Not supported on linked device
         return false;
       }
+
+      return true;
     }
 
     // Determine response type

--- a/src/procedures/iotscape/iotscape.js
+++ b/src/procedures/iotscape/iotscape.js
@@ -158,7 +158,7 @@ IoTScape._send = function (service, id, command, caller) {
     return false;
   }
 
-  return IoTScapeServices.call(service, parts[0], id, ...parts.slice(1));
+  return IoTScapeServices.call(service, parts[0], id, clientId, ...parts.slice(1));
 };
 
 /**

--- a/src/procedures/iotscape/iotscape.js
+++ b/src/procedures/iotscape/iotscape.js
@@ -173,14 +173,18 @@ IoTScape._send = function (service, id, command, caller) {
  * @param {String} definition Service definition
  * @param {RemoteInfo} remote Remote host information
  */
-IoTScape._createService = async function (definition, remote) {
+IoTScape._createService = async function (definition, remote = null) {
   let parsed = null;
 
-  try {
-    parsed = JSON.parse(definition);
-  } catch (err) {
-    logger.log("Error parsing IoTScape service: " + err);
-    return;
+  if (typeof definition === "string") {
+    try {
+      parsed = JSON.parse(definition);
+    } catch (err) {
+      logger.log("Error parsing IoTScape service: " + err);
+      return;
+    }
+  } else {
+    parsed = definition;
   }
 
   // Ignore empty and request messages sent to this method

--- a/src/procedures/iotscape/iotscape.js
+++ b/src/procedures/iotscape/iotscape.js
@@ -174,9 +174,8 @@ IoTScape._send = function (service, id, command, caller) {
  * @param {RemoteInfo} remote Remote host information
  */
 IoTScape._createService = async function (definition, remote = null) {
-  
   let parsed = null;
-  
+
   // Handle buffer input
   if (Buffer.isBuffer(definition)) {
     definition = definition.toString();
@@ -200,7 +199,7 @@ IoTScape._createService = async function (definition, remote = null) {
 
   const name = Object.keys(parsed)[0];
   parsed = parsed[name];
-  
+
   // Verify service definition is in message
   if (typeof (parsed.service) == "undefined") {
     logger.log("Service definition not found in message");

--- a/src/procedures/iotscape/iotscape.js
+++ b/src/procedures/iotscape/iotscape.js
@@ -97,7 +97,7 @@ IoTScape.getMethods = function (service) {
  */
 IoTScape.send = function (service, id, command) {
   return IoTScape._send(service, id, command, this.caller);
-}
+};
 
 /**
  * Internal method for sending a command to a device
@@ -105,10 +105,9 @@ IoTScape.send = function (service, id, command) {
  * @param {String} id ID of device to make call to
  * @param {String} command Input to RPC
  * @param {Object} caller The caller object from the RPC
- * @returns 
+ * @returns
  */
 IoTScape._send = function (service, id, command, caller) {
-  
   const clientId = caller.clientId;
 
   if (!IoTScapeServices.serviceExists(service)) {
@@ -132,7 +131,6 @@ IoTScape._send = function (service, id, command, caller) {
     seqNum = parseInt(parts[0]);
     parts = parts.slice(1);
   }
-  
 
   // Allow for RoboScape-esque "set"/"get" commands to be implemented simpler (e.g. "set speed" becomes "setSpeed" instead of a "set" method)
   if (parts.length >= 2) {
@@ -157,7 +155,7 @@ IoTScape._send = function (service, id, command, caller) {
 
   // Check that call will be accepted
   if (!IoTScapeDevices.accepts(service, id, clientId, seqNum)) {
-    logger.log('Call not accepted');
+    logger.log("Call not accepted");
     return false;
   }
 

--- a/src/procedures/iotscape/iotscape.js
+++ b/src/procedures/iotscape/iotscape.js
@@ -119,7 +119,7 @@ IoTScape.send = function (service, id, command) {
       if (IoTScapeServices.functionExists(service, methodName)) {
         parts = [methodName, ...parts.slice(2)];
       } else {
-        // Attempt with three words
+        // Attempt with three words (e.g. "set client rate" becomes "setClientRate" instead of a "set" method)
         if (parts.length >= 3) {
           methodName = parts[0] + parts[1][0].toUpperCase() +
             parts[1].slice(1) +

--- a/src/procedures/iotscape/iotscape.js
+++ b/src/procedures/iotscape/iotscape.js
@@ -17,6 +17,9 @@ const logger = require("../utils/logger")("iotscape");
 const Storage = require("../../storage");
 const ServiceEvents = require("../utils/service-events");
 const IoTScapeServices = require("./iotscape-services");
+const IoTScapeDevices = require('./iotscape-devices');
+const Filter = require('bad-words'),
+    filter = new Filter();
 
 const normalizeServiceName = (name) =>
   name.toLowerCase().replace(/[^a-z0-9]/g, "");
@@ -54,7 +57,7 @@ IoTScape.getDevices = function (service) {
     throw new Error("Service not found");
   }
 
-  return IoTScapeServices.getDevices(service);
+  return IoTScapeDevices.getDevices(service);
 };
 
 /**
@@ -75,6 +78,18 @@ IoTScape.getMessageTypes = function (service) {
 };
 
 /**
+ * List the methods associated with a service
+ * @param {String} service Name of service to get methods for
+ */
+IoTScape.getMethods = function(service){
+  if(!IoTScapeServices.serviceExists(service)){
+      throw new Error('Service not found');
+  }
+
+  return IoTScapeServices.getMethods(service);
+};
+
+/**
  * Make a call to a device as a text command
  * @param {String} service Name of service to make call to
  * @param {String} id ID of device to make call to
@@ -85,15 +100,25 @@ IoTScape.send = function (service, id, command) {
     throw new Error("Service not found");
   }
 
-  if (!IoTScapeServices.deviceExists(service, id)) {
+  if (!IoTScapeDevices.deviceExists(service, id)) {
     throw new Error("Device not found");
   }
 
-  let parts = command.split(/\s+/g);
+  let parts = IoTScapeDevices.deviceDecrypt(service, id, command).split(/\s+/g);
+
 
   // Require at least a function name
   if (parts.length < 1) {
     throw new Error("Command too short or invalid");
+  }
+
+  // Allow for RoboScape-esque "set"/"get" commands to be implemented simpler (e.g. "set speed" becomes "setSpeed" instead of a "set" method)
+  if(parts.length >= 2) {
+    // Don't modify if service actually has a method named "set" or "get"
+    if((parts[0].toLowerCase() == 'set' && !IoTScapeServices.functionExists(service, 'set')) || (parts[0].toLowerCase() == 'get' && !IoTScapeServices.functionExists(service, 'get'))) {
+        parts[0] += parts[1][0].toUpperCase() + parts[1].substr(1);
+        parts.splice(1,1);
+    }
   }
 
   return IoTScapeServices.call(service, parts[0], id, ...parts.slice(1));
@@ -106,7 +131,7 @@ IoTScape.send = function (service, id, command) {
  * @param {RemoteInfo} remote Remote host information
  */
 IoTScape._createService = async function (definition, remote) {
-  let parsed;
+  let parsed = null;
 
   try {
     parsed = JSON.parse(definition);
@@ -115,16 +140,16 @@ IoTScape._createService = async function (definition, remote) {
     return;
   }
 
-  // Ignore request messages sent to this method
-  if (parsed.request) {
+  // Ignore empty and request messages sent to this method
+  if(parsed == null || parsed.request){
     return;
   }
 
   const name = Object.keys(parsed)[0];
   parsed = parsed[name];
 
-  // Verify service definition in message
-  if (parsed.service == undefined) {
+  // Verify service definition is in message
+  if(typeof(parsed.service) == 'undefined'){
     return;
   }
 
@@ -135,7 +160,8 @@ IoTScape._createService = async function (definition, remote) {
   }
 
   const serviceInfo = parsed.service;
-  const methodsInfo = parsed.methods;
+  const methodsInfo = parsed.methods || {};
+  let methods = _generateMethods(methodsInfo);
 
   // Validate method names
   if (
@@ -149,13 +175,16 @@ IoTScape._createService = async function (definition, remote) {
   }
 
   const version = serviceInfo.version;
-  const id = parsed.id;
+  const id = parsed.id.trim();
 
   logger.log(
     `Received definition for service ${name} v${version} from ID ${id}`,
   );
 
-  let methods = _generateMethods(methodsInfo);
+  if(!IoTScape._validateServiceStrings(name, id, serviceInfo, methods)){
+    logger.log(`Service ${name} rejected due to invalid string`);
+    return;
+  }
 
   let service = {
     name: name,
@@ -197,67 +226,134 @@ IoTScape._createService = async function (definition, remote) {
 };
 
 /**
+ * Check that strings provided in a service definition are valid and free of profanity
+ * @returns {boolean} Were the strings for this service considered valid
+ */
+IoTScape._validateServiceStrings = function(name, id, serviceInfo, methods){
+  // Validate service name
+  if(!isValidServiceName(name) || name.replace(/[^a-zA-Z0-9]/g, '') !== name || filter.isProfane(name.replace(/[A-Z]/g, ' $&'))){
+      logger.log(`Service name ${name} rejected`);
+      return false;
+  }
+
+  if(id == '' || filter.isProfane(id.replace(/[A-Z]/g, ' $&'))){
+      logger.log('ID invalid');
+      return false;
+  }
+
+  // Additional profanity checks
+  if(filter.isProfane(serviceInfo.description) || methods.map(method => method.name).some(name => !isValidRPCName(name) || filter.isProfane(name)) || methods.map(method => method.documentation).some(doc => filter.isProfane(doc))){
+      logger.log(`Definition for service ${name} rejected`);
+      return false;
+  }
+
+  return true;
+};
+
+// Methods used for all device services but not included in definitions
+const _defaultMethods = [{
+  name: 'getDevices',
+  documentation: 'Get a list of device IDs for this service',
+  arguments: [],
+  returns: {
+      documentation: '',
+      type: ['void']
+  }
+}, 
+{
+  name: 'listen',
+  documentation: 'Register for receiving messages from the given id',
+  arguments: [{
+      name: 'id',
+      optional: false,
+      documentation: 'ID of device to listen to messages from',
+  }],
+  returns: {
+      documentation: '',
+      type: ['void']
+  }
+},
+{
+  name: 'send',
+  documentation: 'Send a text-based message to the service',
+  arguments: [{
+      name: 'id',
+      optional: false,
+      documentation: 'ID of device to send request to',
+  },
+  {
+      name: 'command',
+      optional: false,
+      documentation: 'Request to send to device',
+  }],
+  returns: {
+      documentation: '',
+      type: ['any']
+  }
+},
+{
+  name: 'getMessageTypes',
+  documentation: 'Register for receiving messages from the given id',
+  arguments: [],
+  returns: {
+      documentation: '',
+      type: ['array']
+  }
+},
+{
+  name: 'getMethods',
+  documentation: 'Get methods associated with this service',
+  arguments: [],
+  returns: {
+      documentation: '',
+      type: ['array']
+  }
+}];
+
+/**
  * Creates definitions for methods of an incoming service
  * @param {Object} methodsInfo Methods from parsed JSON data
  */
 function _generateMethods(methodsInfo) {
-  // Add getDevices and listen methods by default
-  let methods = [
-    {
-      name: "getDevices",
-      documentation: "Get a list of device IDs for this service",
-      arguments: [],
-      returns: {
-        documentation: "",
-        type: ["void"],
-      },
-    },
-    {
-      name: "listen",
-      documentation: "Register for receiving messages from the given id",
-      arguments: [{
-        name: "id",
-        optional: false,
-        documentation: "ID of device to send request to",
-      }],
-      returns: {
-        documentation: "",
-        type: ["void"],
-      },
-    },
-    ...Object.keys(methodsInfo).map((methodName) => {
-      const methodInfo = methodsInfo[methodName];
+  if(!methodsInfo){
+      logger.error("No methods definition for service");
+      return [];
+  }
+  try {
+    // Add default methods first
+    let methods = [..._defaultMethods, ...Object.keys(methodsInfo).map(methodName => {
+        const methodInfo = methodsInfo[methodName];
 
-      const method = {
-        name: methodName,
-        documentation: methodInfo.documentation,
-        returns: methodInfo.returns,
-      };
+        if(!methodInfo){
+            throw new Error("Undefined method " + methodName);
+        }
 
-      method.arguments = methodInfo.params.map((param) => {
-        let type = param.type === "number"
-          ? { name: "Number", params: [] }
-          : null;
-        return {
-          name: param.name,
-          optional: param.optional,
-          documentation: param.documentation,
-          type,
-        };
-      });
+        const method = { name: methodName, documentation: methodInfo.documentation, categories: [['Basic']],  returns: methodInfo.returns };
 
-      // Add ID argument to all non-getDevices methods
-      method.arguments = [{
-        name: "id",
-        optional: false,
-        documentation: "ID of device to send request to",
-      }, ...method.arguments];
+        method.arguments = methodInfo.params.map(param => {
+            let type = param.type === 'number' ? { name: 'Number', params: [] } : null;
+            return {
+                name: param.name,
+                optional: param.optional,
+                documentation: param.documentation,
+                type
+            };
+        });
 
-      return method;
-    }),
-  ];
+        // Add ID argument to all non-getDevices methods
+        method.arguments = [{
+            name: 'id',
+            optional: false,
+            documentation: 'ID of device to send request to',
+        }, ...method.arguments];
 
-  return methods;
+        return method;
+    })];
+      return methods;
+  } catch (error) {
+      logger.err(error);
+      return [];
+  }
 }
 
 /**

--- a/src/procedures/iotscape/iotscape.js
+++ b/src/procedures/iotscape/iotscape.js
@@ -155,7 +155,6 @@ IoTScape._send = function (service, id, command, caller) {
 
   // Check that call will be accepted
   if (!IoTScapeDevices.accepts(service, id, clientId, seqNum)) {
-    logger.log("Call not accepted");
     return false;
   }
 

--- a/src/procedures/iotscape/iotscape.js
+++ b/src/procedures/iotscape/iotscape.js
@@ -158,7 +158,13 @@ IoTScape._send = function (service, id, command, caller) {
     return false;
   }
 
-  return IoTScapeServices.call(service, parts[0], id, clientId, ...parts.slice(1));
+  return IoTScapeServices.call(
+    service,
+    parts[0],
+    id,
+    clientId,
+    ...parts.slice(1),
+  );
 };
 
 /**

--- a/src/procedures/iotscape/iotscape.js
+++ b/src/procedures/iotscape/iotscape.js
@@ -121,7 +121,8 @@ IoTScape.send = function (service, id, command) {
       } else {
         // Attempt with three words
         if (parts.length >= 3) {
-          methodName = parts[0] + parts[1][0].toUpperCase() + parts[1].slice(1) +
+          methodName = parts[0] + parts[1][0].toUpperCase() +
+            parts[1].slice(1) +
             parts[2][0].toUpperCase() + parts[2].slice(1);
           if (IoTScapeServices.functionExists(service, methodName)) {
             parts = [methodName, ...parts.slice(3)];

--- a/src/procedures/iotscape/iotscape.js
+++ b/src/procedures/iotscape/iotscape.js
@@ -113,15 +113,21 @@ IoTScape.send = function (service, id, command) {
 
   // Allow for RoboScape-esque "set"/"get" commands to be implemented simpler (e.g. "set speed" becomes "setSpeed" instead of a "set" method)
   if (parts.length >= 2) {
-    // Don't modify if service actually has a method named "set" or "get"
-    if (
-      (parts[0].toLowerCase() == "set" &&
-        !IoTScapeServices.functionExists(service, "set")) ||
-      (parts[0].toLowerCase() == "get" &&
-        !IoTScapeServices.functionExists(service, "get"))
-    ) {
-      parts[0] += parts[1][0].toUpperCase() + parts[1].substr(1);
-      parts.splice(1, 1);
+    // Combine first word "set", "get", and "reset" with the next words if it's a valid method in the service
+    if (["set", "get", "reset"].includes(parts[0])) {
+      let methodName = parts[0] + parts[1][0].toUpperCase() + parts[1].slice(1);
+      if (IoTScapeServices.functionExists(service, methodName)) {
+        parts = [methodName, ...parts.slice(2)];
+      } else {
+        // Attempt with three words
+        if (parts.length >= 3) {
+          methodName = parts[0] + parts[1][0].toUpperCase() + parts[1].slice(1) +
+            parts[2][0].toUpperCase() + parts[2].slice(1);
+          if (IoTScapeServices.functionExists(service, methodName)) {
+            parts = [methodName, ...parts.slice(3)];
+          }
+        }
+      }
     }
   }
 

--- a/src/procedures/iotscape/iotscape.js
+++ b/src/procedures/iotscape/iotscape.js
@@ -400,7 +400,7 @@ function _generateMethods(methodsInfo) {
         const method = {
           name: methodName,
           documentation: methodInfo.documentation,
-          categories: [["Basic"]],
+          categories: [[]],
           returns: methodInfo.returns,
         };
 

--- a/src/procedures/iotscape/iotscape.js
+++ b/src/procedures/iotscape/iotscape.js
@@ -174,7 +174,13 @@ IoTScape._send = function (service, id, command, caller) {
  * @param {RemoteInfo} remote Remote host information
  */
 IoTScape._createService = async function (definition, remote = null) {
+  
   let parsed = null;
+  
+  // Handle buffer input
+  if (Buffer.isBuffer(definition)) {
+    definition = definition.toString();
+  }
 
   if (typeof definition === "string") {
     try {
@@ -194,9 +200,10 @@ IoTScape._createService = async function (definition, remote = null) {
 
   const name = Object.keys(parsed)[0];
   parsed = parsed[name];
-
+  
   // Verify service definition is in message
   if (typeof (parsed.service) == "undefined") {
+    logger.log("Service definition not found in message");
     return;
   }
 
@@ -269,7 +276,7 @@ IoTScape._createService = async function (definition, remote = null) {
   } else {
     logger.log(`Service ${name} already exists and is up to date`);
   }
-  IoTScapeServices.updateOrCreateServiceInfo(name, parsed, id, remote);
+  IoTScapeServices.updateOrCreateServiceInfo(name, service, id, remote);
 };
 
 /**

--- a/src/procedures/iotscape/iotscape.js
+++ b/src/procedures/iotscape/iotscape.js
@@ -118,6 +118,14 @@ IoTScape._send = function (service, id, command, caller) {
     throw new Error("Device not found");
   }
 
+  // Relay as-is message to listening clients
+  IoTScapeServices.sendMessageToListeningClients(
+    service,
+    id,
+    "device command",
+    { command },
+  );
+
   let parts = IoTScapeDevices.deviceDecrypt(service, id, command).split(/\s+/g);
 
   // Require at least a function name

--- a/src/procedures/iotscape/routes.js
+++ b/src/procedures/iotscape/routes.js
@@ -1,5 +1,8 @@
 const express = require("express");
 const router = express();
+const logger = require("../utils/logger")("iotscape-routes");
+const IoTScape = require("./iotscape");
+const bodyParser = require("body-parser");
 
 router.get(
   "/port",
@@ -9,5 +12,15 @@ router.get(
     );
   },
 );
+
+router.post(
+  "/announce",
+  bodyParser.json({ limit: "1mb" }),
+  async (req, res) => {
+    logger.info(`HTTP announcement from ${req.ip}`);
+    IoTScape._createService(req.body);
+    res.status(200).send("OK");
+  },
+)
 
 module.exports = router;

--- a/src/procedures/iotscape/routes.js
+++ b/src/procedures/iotscape/routes.js
@@ -31,12 +31,21 @@ router.post(
   async (req, res) => {
     if (req.body) {
       // Validate fields
-      if (!req.body.request || !req.body.response || !Array.isArray(req.body.response)) {
+      if (
+        !req.body.request || !req.body.response ||
+        !Array.isArray(req.body.response)
+      ) {
         return res.status(400).send("Invalid request: missing fields");
       }
-      
-      if(Object.keys(IoTScapeServices._awaitingRequests).includes(req.body.request)) {
-        IoTScapeServices._awaitingRequests[req.body.request].resolve(...req.body.response);
+
+      if (
+        Object.keys(IoTScapeServices._awaitingRequests).includes(
+          req.body.request,
+        )
+      ) {
+        IoTScapeServices._awaitingRequests[req.body.request].resolve(
+          ...req.body.response,
+        );
         return res.status(200).send("OK");
       } else {
         return res.status(400).send("No request found for this response.");
@@ -44,7 +53,7 @@ router.post(
     }
 
     res.status(400).send("Invalid request.");
-  }
-)
+  },
+);
 
 module.exports = router;

--- a/src/procedures/iotscape/routes.js
+++ b/src/procedures/iotscape/routes.js
@@ -21,6 +21,6 @@ router.post(
     IoTScape._createService(req.body);
     res.status(200).send("OK");
   },
-)
+);
 
 module.exports = router;

--- a/src/procedures/iotscape/routes.js
+++ b/src/procedures/iotscape/routes.js
@@ -3,6 +3,8 @@ const router = express();
 const logger = require("../utils/logger")("iotscape-routes");
 const IoTScape = require("./iotscape");
 const bodyParser = require("body-parser");
+const IoTScapeDevices = require("./iotscape-devices");
+const IoTScapeServices = require("./iotscape-services");
 
 router.get(
   "/port",
@@ -22,5 +24,27 @@ router.post(
     res.status(200).send("OK");
   },
 );
+
+router.post(
+  "/response",
+  bodyParser.json({ limit: "5mb" }),
+  async (req, res) => {
+    if (req.body) {
+      // Validate fields
+      if (!req.body.request || !req.body.response || !Array.isArray(req.body.response)) {
+        return res.status(400).send("Invalid request: missing fields");
+      }
+      
+      if(Object.keys(IoTScapeServices._awaitingRequests).includes(req.body.request)) {
+        IoTScapeServices._awaitingRequests[req.body.request].resolve(...req.body.response);
+        return res.status(200).send("OK");
+      } else {
+        return res.status(400).send("No request found for this response.");
+      }
+    }
+
+    res.status(400).send("Invalid request.");
+  }
+)
 
 module.exports = router;

--- a/test/procedures/iotscape.spec.js
+++ b/test/procedures/iotscape.spec.js
@@ -4,7 +4,7 @@ describe(utils.suiteName(__filename), function () {
   utils.verifyRPCInterfaces("IoTScape", [
     ["getDevices", ["service"]],
     ["getMessageTypes", ["service"]],
-    ['getMethods', ['service']],
+    ["getMethods", ["service"]],
     ["getServices", []],
     ["send", ["service", "id", "command"]],
   ]);

--- a/test/procedures/iotscape.spec.js
+++ b/test/procedures/iotscape.spec.js
@@ -4,6 +4,7 @@ describe(utils.suiteName(__filename), function () {
   utils.verifyRPCInterfaces("IoTScape", [
     ["getDevices", ["service"]],
     ["getMessageTypes", ["service"]],
+    ['getMethods', ['service']],
     ["getServices", []],
     ["send", ["service", "id", "command"]],
   ]);


### PR DESCRIPTION
Improvements to add the RoboScape cybersecurity features to IoTScape, and then a few more features

 - [x] Set key
 - [x] Get HW key
 - [x] Listen to IoTScape messages
   - [x] Figure out device message vs device command  should be based on RoboScape/PhoneIoT
     - "command" is from send before checking if valid
     - "message" is from device, not needed for IoTScape (they define their own messages)
   - [x] Send invalid commands too
 - [x] Encrypt IoTScape messages
 - [x] Rate limits
 - [x] Sequence numbers
 - [x] Send usernames/client ids to devices (possibly more)
 - [x] "lite" announce, only service name and version
 - [x] Device can request reset of cybersec state
 - [x] Additional endpoints to allow big messages to be passed over HTTP instead (enables images, makes big announcements reliable) - Done for announcements and responses 
 - [x] Test how image/sound data are serialized for "send"
   - Not well, sending one in a string field alone gets XML, trying to join it gets none of the data.

Later possibilities:
 - Look into per-account signing for announcements
 - HTTP route for getting requests, allowing large requests
 - Enum types
 - Further restrict and filter JSON data
 - Devices can request specific cybersec state