### PR TITLE
rpc now returns string names for durations instead of ints

### DIFF
--- a/src/procedures/midi-data/MidiLibrary/midiLibrary.json
+++ b/src/procedures/midi-data/MidiLibrary/midiLibrary.json
@@ -4,564 +4,564 @@
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Invention 1",
-      "Path": "./MidiLibrary/js_bach_inventions_and_sinfonias/bach-invention-01.mid"
+      "Path": "./js_bach_inventions_and_sinfonias/bach-invention-01.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Invention 2",
-      "Path": "./MidiLibrary/js_bach_inventions_and_sinfonias/bach-invention-02.mid"
+      "Path": "./js_bach_inventions_and_sinfonias/bach-invention-02.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Invention 3",
-      "Path": "./MidiLibrary/js_bach_inventions_and_sinfonias/bach-invention-03.mid"
+      "Path": "./js_bach_inventions_and_sinfonias/bach-invention-03.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Invention 4",
-      "Path": "./MidiLibrary/js_bach_inventions_and_sinfonias/bach-invention-04.mid"
+      "Path": "./js_bach_inventions_and_sinfonias/bach-invention-04.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Invention 5",
-      "Path": "./MidiLibrary/js_bach_inventions_and_sinfonias/bach-invention-05.mid"
+      "Path": "./js_bach_inventions_and_sinfonias/bach-invention-05.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Invention 6",
-      "Path": "./MidiLibrary/js_bach_inventions_and_sinfonias/bach-invention-06.mid"
+      "Path": "./js_bach_inventions_and_sinfonias/bach-invention-06.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Invention 7",
-      "Path": "./MidiLibrary/js_bach_inventions_and_sinfonias/bach-invention-07.mid"
+      "Path": "./js_bach_inventions_and_sinfonias/bach-invention-07.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Invention 8",
-      "Path": "./MidiLibrary/js_bach_inventions_and_sinfonias/bach-invention-08.mid"
+      "Path": "./js_bach_inventions_and_sinfonias/bach-invention-08.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Invention 9",
-      "Path": "./MidiLibrary/js_bach_inventions_and_sinfonias/bach-invention-09.mid"
+      "Path": "./js_bach_inventions_and_sinfonias/bach-invention-09.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Invention 10",
-      "Path": "./MidiLibrary/js_bach_inventions_and_sinfonias/bach-invention-10.mid"
+      "Path": "./js_bach_inventions_and_sinfonias/bach-invention-10.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Invention 11",
-      "Path": "./MidiLibrary/js_bach_inventions_and_sinfonias/bach-invention-11.mid"
+      "Path": "./js_bach_inventions_and_sinfonias/bach-invention-11.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Invention 12",
-      "Path": "./MidiLibrary/js_bach_inventions_and_sinfonias/bach-invention-12.mid"
+      "Path": "./js_bach_inventions_and_sinfonias/bach-invention-12.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Invention 13",
-      "Path": "./MidiLibrary/js_bach_inventions_and_sinfonias/bach-invention-13.mid"
+      "Path": "./js_bach_inventions_and_sinfonias/bach-invention-13.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Invention 14",
-      "Path": "./MidiLibrary/js_bach_inventions_and_sinfonias/bach-invention-14.mid"
+      "Path": "./js_bach_inventions_and_sinfonias/bach-invention-14.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Invention 15",
-      "Path": "./MidiLibrary/js_bach_inventions_and_sinfonias/bach-invention-01.mid"
+      "Path": "./js_bach_inventions_and_sinfonias/bach-invention-01.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Sinfonia 1",
-      "Path": "./MidiLibrary/js_bach_inventions_and_sinfonias/bwv787.mid"
+      "Path": "./js_bach_inventions_and_sinfonias/bwv787.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Sinfonia 2",
-      "Path": "./MidiLibrary/js_bach_inventions_and_sinfonias/bwv788.mid"
+      "Path": "./js_bach_inventions_and_sinfonias/bwv788.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Sinfonia 3",
-      "Path": "./MidiLibrary/js_bach_inventions_and_sinfonias/bwv789.mid"
+      "Path": "./js_bach_inventions_and_sinfonias/bwv789.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Sinfonia 4",
-      "Path": "./MidiLibrary/js_bach_inventions_and_sinfonias/bwv790.mid"
+      "Path": "./js_bach_inventions_and_sinfonias/bwv790.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Sinfonia 5",
-      "Path": "./MidiLibrary/js_bach_inventions_and_sinfonias/bwv791.mid"
+      "Path": "./js_bach_inventions_and_sinfonias/bwv791.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Sinfonia 6",
-      "Path": "./MidiLibrary/js_bach_inventions_and_sinfonias/bwv792.mid"
+      "Path": "./js_bach_inventions_and_sinfonias/bwv792.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Sinfonia 7",
-      "Path": "./MidiLibrary/js_bach_inventions_and_sinfonias/bwv793.mid"
+      "Path": "./js_bach_inventions_and_sinfonias/bwv793.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Sinfonia 8",
-      "Path": "./MidiLibrary/js_bach_inventions_and_sinfonias/bwv794.mid"
+      "Path": "./js_bach_inventions_and_sinfonias/bwv794.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Sinfonia 9",
-      "Path": "./MidiLibrary/js_bach_inventions_and_sinfonias/bwv795.mid"
+      "Path": "./js_bach_inventions_and_sinfonias/bwv795.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Sinfonia 10",
-      "Path": "./MidiLibrary/js_bach_inventions_and_sinfonias/bwv796.mid"
+      "Path": "./js_bach_inventions_and_sinfonias/bwv796.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Sinfonia 11",
-      "Path": "./MidiLibrary/js_bach_inventions_and_sinfonias/bwv797.mid"
+      "Path": "./js_bach_inventions_and_sinfonias/bwv797.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Sinfonia 12",
-      "Path": "./MidiLibrary/js_bach_inventions_and_sinfonias/bwv798.mid"
+      "Path": "./js_bach_inventions_and_sinfonias/bwv798.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Sinfonia 13",
-      "Path": "./MidiLibrary/js_bach_inventions_and_sinfonias/bwv799.mid"
+      "Path": "./js_bach_inventions_and_sinfonias/bwv799.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Sinfonia 14",
-      "Path": "./MidiLibrary/js_bach_inventions_and_sinfonias/bwv800.mid"
+      "Path": "./js_bach_inventions_and_sinfonias/bwv800.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Sinfonia 15",
-      "Path": "./MidiLibrary/js_bach_inventions_and_sinfonias/bwv801.mid"
+      "Path": "./js_bach_inventions_and_sinfonias/bwv801.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "English Suite I: Bourree I",
-      "Path": "./MidiLibrary/js_bach_english_suites/bach-english-suite-1-bourree-1.mid"
+      "Path": "./js_bach_english_suites/bach-english-suite-1-bourree-1.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "English Suite I: Bourree II",
-      "Path": "./MidiLibrary/js_bach_english_suites/bach-english-suite-1-bourree-2.mid"
+      "Path": "./js_bach_english_suites/bach-english-suite-1-bourree-2.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "English Suite II: Bourree I",
-      "Path": "./MidiLibrary/js_bach_english_suites/bach-english-suite-2-bourree-1.mid"
+      "Path": "./js_bach_english_suites/bach-english-suite-2-bourree-1.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "English Suite II: Bourree II",
-      "Path": "./MidiLibrary/js_bach_english_suites/bach-english-suite-2-bourree-2.mid"
+      "Path": "./js_bach_english_suites/bach-english-suite-2-bourree-2.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "English Suite II: Gigue",
-      "Path": "./MidiLibrary/js_bach_english_suites/bach-english-suite-2-prelude.mid"
+      "Path": "./js_bach_english_suites/bach-english-suite-2-prelude.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Goldberg Variations - Aria",
-      "Path": "./MidiLibrary/js_bach_goldberg_variations/bwv-988-aria.mid"
+      "Path": "./js_bach_goldberg_variations/bwv-988-aria.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Goldberg Variations - 1",
-      "Path": "./MidiLibrary/js_bach_goldberg_variations/bwv-988-v01.mid"
+      "Path": "./js_bach_goldberg_variations/bwv-988-v01.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Goldberg Variations - 2",
-      "Path": "./MidiLibrary/js_bach_goldberg_variations/bwv-988-v02.mid"
+      "Path": "./js_bach_goldberg_variations/bwv-988-v02.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Goldberg Variations - 3",
-      "Path": "./MidiLibrary/js_bach_goldberg_variations/bwv-988-v03.mid"
+      "Path": "./js_bach_goldberg_variations/bwv-988-v03.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Goldberg Variations - 4",
-      "Path": "./MidiLibrary/js_bach_goldberg_variations/bwv-988-v04.mid"
+      "Path": "./js_bach_goldberg_variations/bwv-988-v04.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Goldberg Variations - 5",
-      "Path": "./MidiLibrary/js_bach_goldberg_variations/bwv-988-v05.mid"
+      "Path": "./js_bach_goldberg_variations/bwv-988-v05.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Goldberg Variations - 6",
-      "Path": "./MidiLibrary/js_bach_goldberg_variations/bwv-988-v06.mid"
+      "Path": "./js_bach_goldberg_variations/bwv-988-v06.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Goldberg Variations - 7",
-      "Path": "./MidiLibrary/js_bach_goldberg_variations/bwv-988-v07.mid"
+      "Path": "./js_bach_goldberg_variations/bwv-988-v07.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Goldberg Variations - 8",
-      "Path": "./MidiLibrary/js_bach_goldberg_variations/bwv-988-v08.mid"
+      "Path": "./js_bach_goldberg_variations/bwv-988-v08.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Goldberg Variations - 9",
-      "Path": "./MidiLibrary/js_bach_goldberg_variations/bwv-988-v09.mid"
+      "Path": "./js_bach_goldberg_variations/bwv-988-v09.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Goldberg Variations - 10",
-      "Path": "./MidiLibrary/js_bach_goldberg_variations/bwv-988-v10.mid"
+      "Path": "./js_bach_goldberg_variations/bwv-988-v10.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Goldberg Variations - 11",
-      "Path": "./MidiLibrary/js_bach_goldberg_variations/bwv-988-v11.mid"
+      "Path": "./js_bach_goldberg_variations/bwv-988-v11.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Goldberg Variations - 12",
-      "Path": "./MidiLibrary/js_bach_goldberg_variations/bwv-988-v12.mid"
+      "Path": "./js_bach_goldberg_variations/bwv-988-v12.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Goldberg Variations - 13",
-      "Path": "./MidiLibrary/js_bach_goldberg_variations/bwv-988-v13.mid"
+      "Path": "./js_bach_goldberg_variations/bwv-988-v13.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Goldberg Variations - 14",
-      "Path": "./MidiLibrary/js_bach_goldberg_variations/bwv-988-v14.mid"
+      "Path": "./js_bach_goldberg_variations/bwv-988-v14.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Goldberg Variations - 15",
-      "Path": "./MidiLibrary/js_bach_goldberg_variations/bwv-988-v15.mid"
+      "Path": "./js_bach_goldberg_variations/bwv-988-v15.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Goldberg Variations - 16",
-      "Path": "./MidiLibrary/js_bach_goldberg_variations/bwv-988-v16.mid"
+      "Path": "./js_bach_goldberg_variations/bwv-988-v16.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Goldberg Variations - 17",
-      "Path": "./MidiLibrary/js_bach_goldberg_variations/bwv-988-v17.mid"
+      "Path": "./js_bach_goldberg_variations/bwv-988-v17.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Goldberg Variations - 18",
-      "Path": "./MidiLibrary/js_bach_goldberg_variations/bwv-988-v18.mid"
+      "Path": "./js_bach_goldberg_variations/bwv-988-v18.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Goldberg Variations - 19",
-      "Path": "./MidiLibrary/js_bach_goldberg_variations/bwv-988-v19.mid"
+      "Path": "./js_bach_goldberg_variations/bwv-988-v19.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Goldberg Variations - 20",
-      "Path": "./MidiLibrary/js_bach_goldberg_variations/bwv-988-v20.mid"
+      "Path": "./js_bach_goldberg_variations/bwv-988-v20.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Name": "Goldberg Variations - 21",
-      "Path": "./MidiLibrary/js_bach_goldberg_variations/bwv-988-v21.mid"
+      "Path": "./js_bach_goldberg_variations/bwv-988-v21.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Goldberg Variations - 22",
-      "Path": "./MidiLibrary/js_bach_goldberg_variations/bwv-988-v22.mid"
+      "Path": "./js_bach_goldberg_variations/bwv-988-v22.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Goldberg Variations - 23",
-      "Path": "./MidiLibrary/js_bach_goldberg_variations/bwv-988-v23.mid"
+      "Path": "./js_bach_goldberg_variations/bwv-988-v23.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Goldberg Variations - 24",
-      "Path": "./MidiLibrary/js_bach_goldberg_variations/bwv-988-v24.mid"
+      "Path": "./js_bach_goldberg_variations/bwv-988-v24.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Goldberg Variations - 25",
-      "Path": "./MidiLibrary/js_bach_goldberg_variations/bwv-988-v25.mid"
+      "Path": "./js_bach_goldberg_variations/bwv-988-v25.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Goldberg Variations - 26",
-      "Path": "./MidiLibrary/js_bach_goldberg_variations/bwv-988-v26.mid"
+      "Path": "./js_bach_goldberg_variations/bwv-988-v26.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Goldberg Variations - 27",
-      "Path": "./MidiLibrary/js_bach_goldberg_variations/bwv-988-v27.mid"
+      "Path": "./js_bach_goldberg_variations/bwv-988-v27.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Goldberg Variations - 28",
-      "Path": "./MidiLibrary/js_bach_goldberg_variations/bwv-988-v28.mid"
+      "Path": "./js_bach_goldberg_variations/bwv-988-v28.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Goldberg Variations - 29",
-      "Path": "./MidiLibrary/js_bach_goldberg_variations/bwv-988-v29.mid"
+      "Path": "./js_bach_goldberg_variations/bwv-988-v29.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Goldberg Variations - 30",
-      "Path": "./MidiLibrary/js_bach_goldberg_variations/bwv-988-v30.mid"
+      "Path": "./js_bach_goldberg_variations/bwv-988-v30.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Lute Suite BWV 997: 1. Prelude",
-      "Path": "./MidiLibrary/js_bach_lute_suite/bwv997-01prelude.mid"
+      "Path": "./js_bach_lute_suite/bwv997-01prelude.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Lute Suite BWV 997: 2. Fuga",
-      "Path": "./MidiLibrary/js_bach_lute_suite/bwv997-02fuga.mid"
+      "Path": "./js_bach_lute_suite/bwv997-02fuga.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Lute Suite BWV 997: 3. Sarabande",
-      "Path": "./MidiLibrary/js_bach_lute_suite/bwv997-03sarabande.mid"
+      "Path": "./js_bach_lute_suite/bwv997-03sarabande.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Lute Suite BWV 997: 4. Gigue",
-      "Path": "./MidiLibrary/js_bach_lute_suite/bwv997-04gigue.mid"
+      "Path": "./js_bach_lute_suite/bwv997-04gigue.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "Lute Suite BWV 997: 5. Double",
-      "Path": "./MidiLibrary/js_bach_lute_suite/bwv997-05double.mid"
+      "Path": "./js_bach_lute_suite/bwv997-05double.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "14 Canons - 1",
-      "Path": "./MidiLibrary/js_bach_14_canons/bwv-1087-01.mid"
+      "Path": "./js_bach_14_canons/bwv-1087-01.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "14 Canons - 2",
-      "Path": "./MidiLibrary/js_bach_14_canons/bwv-1087-02.mid"
+      "Path": "./js_bach_14_canons/bwv-1087-02.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "14 Canons - 3",
-      "Path": "./MidiLibrary/js_bach_14_canons/bwv-1087-03.mid"
+      "Path": "./js_bach_14_canons/bwv-1087-03.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "14 Canons - 4",
-      "Path": "./MidiLibrary/js_bach_14_canons/bwv-1087-04.mid"
+      "Path": "./js_bach_14_canons/bwv-1087-04.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "14 Canons - 5",
-      "Path": "./MidiLibrary/js_bach_14_canons/bwv-1087-05.mid"
+      "Path": "./js_bach_14_canons/bwv-1087-05.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "14 Canons - 6",
-      "Path": "./MidiLibrary/js_bach_14_canons/bwv-1087-06.mid"
+      "Path": "./js_bach_14_canons/bwv-1087-06.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "14 Canons - 7",
-      "Path": "./MidiLibrary/js_bach_14_canons/bwv-1087-07.mid"
+      "Path": "./js_bach_14_canons/bwv-1087-07.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "14 Canons - 8",
-      "Path": "./MidiLibrary/js_bach_14_canons/bwv-1087-08.mid"
+      "Path": "./js_bach_14_canons/bwv-1087-08.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "14 Canons - 9",
-      "Path": "./MidiLibrary/js_bach_14_canons/bwv-1087-09.mid"
+      "Path": "./js_bach_14_canons/bwv-1087-09.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "14 Canons - 10",
-      "Path": "./MidiLibrary/js_bach_14_canons/bwv-1087-10.mid"
+      "Path": "./js_bach_14_canons/bwv-1087-10.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "14 Canons - 11",
-      "Path": "./MidiLibrary/js_bach_14_canons/bwv-1087-11.mid"
+      "Path": "./js_bach_14_canons/bwv-1087-11.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "14 Canons - 12",
-      "Path": "./MidiLibrary/js_bach_14_canons/bwv-1087-12.mid"
+      "Path": "./js_bach_14_canons/bwv-1087-12.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "14 Canons - 13",
-      "Path": "./MidiLibrary/js_bach_14_canons/bwv-1087-13.mid"
+      "Path": "./js_bach_14_canons/bwv-1087-13.mid"
     },
     {
       "Composer": "J.S. Bach",
       "Style": "Baroque",
       "Name": "14 Canons - 14",
-      "Path": "./MidiLibrary/js_bach_14_canons/bwv-1087-14.mid"
+      "Path": "./js_bach_14_canons/bwv-1087-14.mid"
     },
     {
       "Composer": "Beethoven",
       "Style": "Classical",
       "Name": "Sonata No. 1 (1st Movement: Allegro)",
-      "Path": "./MidiLibrary/beethoven_piano_sonatas/LVB_Sonate_02no1_1.mid"
+      "Path": "./beethoven_piano_sonatas/LVB_Sonate_02no1_1.mid"
     },
     {
       "Composer": "Beethoven",
       "Style": "Classical",
       "Name": "Sonata No. 1 (2nd Movement: Adagio)",
-      "Path": "./MidiLibrary/beethoven_piano_sonatas/LVB_Sonate_02no1_2.mid"
+      "Path": "./beethoven_piano_sonatas/LVB_Sonate_02no1_2.mid"
     },
     {
       "Composer": "Beethoven",
       "Style": "Classical",
       "Name": "Sonata No. 1 (3rd Movement: Allegretto)",
-      "Path": "./MidiLibrary/beethoven_piano_sonatas/LVB_Sonate_02no1_3.mid"
+      "Path": "./beethoven_piano_sonatas/LVB_Sonate_02no1_3.mid"
     },
     {
       "Composer": "Beethoven",
       "Style": "Classical",
       "Name": "Sonata No. 1 (4th Movement: Prestissimo)",
-      "Path": "./MidiLibrary/beethoven_piano_sonatas/LVB_Sonate_02no1_4.mid"
+      "Path": "./beethoven_piano_sonatas/LVB_Sonate_02no1_4.mid"
     },
     {
       "Composer": "Beethoven",
       "Style": "Classical",
       "Name": "Sonata No. 5 (1st Movement: Allegro molto e con brio)",
-      "Path": "./MidiLibrary/beethoven_piano_sonatas/LVB_Sonate_10no1_1.mid"
+      "Path": "./beethoven_piano_sonatas/LVB_Sonate_10no1_1.mid"
     },
     {
       "Composer": "Beethoven",
       "Style": "Classical",
       "Name": "Sonata No. 5 (3rd Movement: Prestissimo)",
-      "Path": "./MidiLibrary/beethoven_piano_sonatas/LVB_Sonate_10no1_3.mid"
+      "Path": "./beethoven_piano_sonatas/LVB_Sonate_10no1_3.mid"
     },
     {
       "Composer": "Beethoven",
       "Style": "Classical",
       "Name": "Sonata No. 6 (1st Movement: Allegro)",
-      "Path": "./MidiLibrary/beethoven_piano_sonatas/lvb_sonate_10no2_1.mid"
+      "Path": "./beethoven_piano_sonatas/lvb_sonate_10no2_1.mid"
     },
     {
       "Composer": "Beethoven",
       "Style": "Classical",
       "Name": "Sonata No. 6 (2nd Movement: Allegretto)",
-      "Path": "./MidiLibrary/beethoven_piano_sonatas/lvb_sonate_10no2_2.mid"
+      "Path": "./beethoven_piano_sonatas/lvb_sonate_10no2_2.mid"
     },
     {
       "Composer": "Beethoven",
       "Style": "Classical",
       "Name": "Sonata No. 6 (3rd Movement: Presto)",
-      "Path": "./MidiLibrary/beethoven_piano_sonatas/lvb_sonate_10no2_3.mid"
+      "Path": "./beethoven_piano_sonatas/lvb_sonate_10no2_3.mid"
     },
     {
       "Composer": "Mozart",

--- a/src/procedures/midi-data/midi-api.js
+++ b/src/procedures/midi-data/midi-api.js
@@ -37,6 +37,16 @@ const HEX_TO_INT = {
   "E": 14,
   "F": 15,
 };
+const NOTE_DURATION_LENGTHS = [
+  0.125, 0.1875, 0.21875, 0.25, 0.375, 0.4375, 0.5,
+  0.75, 0.875, 1, 1.5, 1.75, 2, 3, 3.5, 4, 6, 7
+];
+const NOTE_DURATION_NAMES = [
+  'ThirtySecond', 'DottedThirtySecond', 'DoubleDottedThirtySecond', 'Sixteenth',
+  'DottedSixteenth', 'DoubleDottedSixteenth', 'Eighth', 'DottedEighth', 'DoubleDottedEighth',
+  'Quarter', 'DottedQuarter', 'DoubleDottedQuarter', 'Half', 'DottedHalf', 'DoubleDottedHalf',
+  'Whole', 'DottedWhole', 'DoubleDottedWhole'
+];
 
 function Note(value, duration) {
   this.value = value;
@@ -255,8 +265,8 @@ class TrackChunkNode extends TreeNode {
       if (notesRecord[commands[i].note] === undefined) {
         notesRecord[commands[i].note] = commands[i].time;
       } else {
-        const duration = (commands[i].time - notesRecord[commands[i].note]) /
-          division;
+        const durInt = (commands[i].time - notesRecord[commands[i].note]) / division;
+        const duration = durationFromInt(durInt);
         notes.push(new Note(commands[i].note, duration));
         notesRecord[commands[i].note] = undefined;
       }
@@ -767,6 +777,32 @@ function getTrackEvents(arraybuffer) {
   }
 
   return trackEvents;
+}
+
+/**
+ * @description - converts a beat length into a name for a music duration.
+ * @param {Number} beatLength 
+ * @returns {String}
+ */
+function durationFromInt (beatLength) {
+  let index = NOTE_DURATION_LENGTHS.indexOf(beatLength);
+  if (index !== -1) return NOTE_DURATION_NAMES[index];
+
+  let duration = '';
+  while (beatLength >= NOTE_DURATION_LENGTHS[0]) {
+    for (let i = 0; i < NOTE_DURATION_LENGTHS.length; i++) {
+      if (i === NOTE_DURATION_LENGTHS.length - 1 && beatLength >= NOTE_DURATION_LENGTHS[i]) 
+        index = i;
+      else if (beatLength < NOTE_DURATION_LENGTHS[i]) {
+        index = i - 1;
+        break;
+      }
+    }
+    duration += duration === '' ? 
+      `${NOTE_DURATION_NAMES[index]}` : `+${NOTE_DURATION_NAMES[index]}`;
+    beatLength -= NOTE_DURATION_LENGTHS[index];
+  }
+  return duration === '' ? NOTE_DURATION_NAMES[0] : duration;
 }
 
 module.exports = { MidiReader };

--- a/src/procedures/midi-data/midi-api.js
+++ b/src/procedures/midi-data/midi-api.js
@@ -38,14 +38,44 @@ const HEX_TO_INT = {
   "F": 15,
 };
 const NOTE_DURATION_LENGTHS = [
-  0.125, 0.1875, 0.21875, 0.25, 0.375, 0.4375, 0.5,
-  0.75, 0.875, 1, 1.5, 1.75, 2, 3, 3.5, 4, 6, 7
+  0.125,
+  0.1875,
+  0.21875,
+  0.25,
+  0.375,
+  0.4375,
+  0.5,
+  0.75,
+  0.875,
+  1,
+  1.5,
+  1.75,
+  2,
+  3,
+  3.5,
+  4,
+  6,
+  7,
 ];
 const NOTE_DURATION_NAMES = [
-  'ThirtySecond', 'DottedThirtySecond', 'DoubleDottedThirtySecond', 'Sixteenth',
-  'DottedSixteenth', 'DoubleDottedSixteenth', 'Eighth', 'DottedEighth', 'DoubleDottedEighth',
-  'Quarter', 'DottedQuarter', 'DoubleDottedQuarter', 'Half', 'DottedHalf', 'DoubleDottedHalf',
-  'Whole', 'DottedWhole', 'DoubleDottedWhole'
+  "ThirtySecond",
+  "DottedThirtySecond",
+  "DoubleDottedThirtySecond",
+  "Sixteenth",
+  "DottedSixteenth",
+  "DoubleDottedSixteenth",
+  "Eighth",
+  "DottedEighth",
+  "DoubleDottedEighth",
+  "Quarter",
+  "DottedQuarter",
+  "DoubleDottedQuarter",
+  "Half",
+  "DottedHalf",
+  "DoubleDottedHalf",
+  "Whole",
+  "DottedWhole",
+  "DoubleDottedWhole",
 ];
 
 function Note(value, duration) {
@@ -265,7 +295,8 @@ class TrackChunkNode extends TreeNode {
       if (notesRecord[commands[i].note] === undefined) {
         notesRecord[commands[i].note] = commands[i].time;
       } else {
-        const durInt = (commands[i].time - notesRecord[commands[i].note]) / division;
+        const durInt = (commands[i].time - notesRecord[commands[i].note]) /
+          division;
         const duration = durationFromInt(durInt);
         notes.push(new Note(commands[i].note, duration));
         notesRecord[commands[i].note] = undefined;
@@ -781,28 +812,32 @@ function getTrackEvents(arraybuffer) {
 
 /**
  * @description - converts a beat length into a name for a music duration.
- * @param {Number} beatLength 
+ * @param {Number} beatLength
  * @returns {String}
  */
-function durationFromInt (beatLength) {
+function durationFromInt(beatLength) {
   let index = NOTE_DURATION_LENGTHS.indexOf(beatLength);
   if (index !== -1) return NOTE_DURATION_NAMES[index];
 
-  let duration = '';
+  let duration = "";
   while (beatLength >= NOTE_DURATION_LENGTHS[0]) {
     for (let i = 0; i < NOTE_DURATION_LENGTHS.length; i++) {
-      if (i === NOTE_DURATION_LENGTHS.length - 1 && beatLength >= NOTE_DURATION_LENGTHS[i]) 
+      if (
+        i === NOTE_DURATION_LENGTHS.length - 1 &&
+        beatLength >= NOTE_DURATION_LENGTHS[i]
+      ) {
         index = i;
-      else if (beatLength < NOTE_DURATION_LENGTHS[i]) {
+      } else if (beatLength < NOTE_DURATION_LENGTHS[i]) {
         index = i - 1;
         break;
       }
     }
-    duration += duration === '' ? 
-      `${NOTE_DURATION_NAMES[index]}` : `+${NOTE_DURATION_NAMES[index]}`;
+    duration += duration === ""
+      ? `${NOTE_DURATION_NAMES[index]}`
+      : `+${NOTE_DURATION_NAMES[index]}`;
     beatLength -= NOTE_DURATION_LENGTHS[index];
   }
-  return duration === '' ? NOTE_DURATION_NAMES[0] : duration;
+  return duration === "" ? NOTE_DURATION_NAMES[0] : duration;
 }
 
 module.exports = { MidiReader };


### PR DESCRIPTION
This just changes the way that durations are returned in the API to be more compatible with the blocks we have. It also fixes some errors with the midi library json file.