### PR TITLE
Add support for sending messages to external clients

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -195,12 +195,12 @@ class ServicesAPI {
       );
     }
 
-    // TODO: add support for external states, too?
     const projectId = state?.browser?.projectId;
     const roleId = state?.browser?.roleId;
 
     ctx.caller = {
       username,
+      state,
       projectId,
       roleId,
       clientId,
@@ -214,7 +214,7 @@ class ServicesAPI {
         ctx.apiKey = apiKeyValue;
       }
     }
-    ctx.socket = new RemoteClient(projectId, roleId, clientId);
+    ctx.socket = new RemoteClient(state, clientId);
 
     const args = this.getArguments(serviceName, rpcName, req);
 

--- a/src/messages.js
+++ b/src/messages.js
@@ -18,14 +18,13 @@ class SendMessage extends Message {
   }
 }
 
+/**
+ * Create a message to be sent to a given client.
+ *
+ * If a state is provided, it will only be delivered if the state hasn't changed.
+ */
 class SendMessageToClient extends Message {
-  constructor(projectId, roleId, clientId, type, contents) {
-    const state = {
-      browser: {
-        projectId,
-        roleId,
-      },
-    };
+  constructor(state, clientId, type, contents) {
     const target = { client: { state, clientId } };
     super(target, type, contents);
   }

--- a/src/procedures/alexa/skill.js
+++ b/src/procedures/alexa/skill.js
@@ -23,8 +23,7 @@ class AlexaSkill {
       context.username = username;
     }
     const socket = new RemoteClient(
-      context.projectId,
-      context.roleId,
+      context.state,
       null,
       username,
     );

--- a/src/remote-client.js
+++ b/src/remote-client.js
@@ -9,6 +9,7 @@ const NetsBloxCloud = require("./cloud-client");
 class RemoteClient {
   constructor(state, clientId, username) {
     this.state = state;
+    this.clientId = clientId;
     this.projectId = state?.browser?.projectId;
     this.roleId = state?.browser?.roleId;
     this.username = username;

--- a/src/remote-client.js
+++ b/src/remote-client.js
@@ -7,9 +7,10 @@ const {
 const NetsBloxCloud = require("./cloud-client");
 
 class RemoteClient {
-  constructor(projectId, roleId, clientId, username) {
-    this.projectId = projectId;
-    this.clientId = clientId;
+  constructor(state, clientId, username) {
+    this.state = state;
+    this.projectId = state?.browser?.projectId;
+    this.roleId = state?.browser?.roleId;
     this.roleId = roleId;
     this.username = username;
   }
@@ -17,8 +18,7 @@ class RemoteClient {
   async sendMessage(type, contents = {}) {
     return NetsBloxCloud.sendMessage(
       new SendMessageToClient(
-        this.projectId,
-        this.roleId,
+        this.state,
         this.clientId,
         type,
         contents,

--- a/src/remote-client.js
+++ b/src/remote-client.js
@@ -11,7 +11,6 @@ class RemoteClient {
     this.state = state;
     this.projectId = state?.browser?.projectId;
     this.roleId = state?.browser?.roleId;
-    this.roleId = roleId;
     this.username = username;
   }
 


### PR DESCRIPTION
This adds support for external clients wrt messages originating from services. However, some services require the room/role concept which is not supported by external clients. These will still not receive messages.

At a high level, the message sending API on the cloud supports sending the client state. If the client's state has changed by the time the message is sent, the message will be dropped. Currently, it assumes every client is a browser client. This is problematic bc that means the NetsBlox cloud will drop _every_ message for external clients.

This PR updates this logic to simply pass the state received from the client along to the NetsBlox cloud - rather than reconstruct it (incorrectly).

**Note: This hasn't been tested.**